### PR TITLE
Permit a module to declare child modules.

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -90,7 +90,7 @@
         <module name="CovariantEquals"/>
         <module name="DoubleCheckedLocking"/>
         <module name="EmptyStatement"/>
-        <module name="EqualsAvoidNull"/>
+        <!--<module name="EqualsAvoidNull"/>-->
         <module name="EqualsHashCode"/>
         <!--module name="HiddenField"/-->
         <module name="IllegalInstantiation"/>

--- a/core/src/main/java/com/squareup/objectgraph/Module.java
+++ b/core/src/main/java/com/squareup/objectgraph/Module.java
@@ -30,10 +30,24 @@ public @interface Module {
   Class<?>[] staticInjections() default { };
 
   /**
-   * True if @Provides methods from this module are permitted to override those
-   * of other modules. This is a dangerous feature as it permits binding
-   * conflicts to go unnoticed. It should only be used in test and development
-   * modules.
+   * True if {@code @Provides} methods from this module are permitted to
+   * override those of other modules. This is a dangerous feature as it permits
+   * binding conflicts to go unnoticed. It should only be used in test and
+   * development modules.
    */
   boolean overrides() default false;
+
+  /**
+   * Additional {@code @Module}-annotated classes that this module is composed
+   * of. The contributions of the modules in {@code children}, and of their
+   * children recursively, are all contributed to the object graph.
+   */
+  Class<?>[] children() default { };
+
+  /**
+   * True if all of the bindings required by this module can also be satisfied
+   * by this module. If a module is complete it is eligible for additional
+   * static checking: tools can detect if required bindings are not available.
+   */
+  boolean complete() default false;
 }

--- a/core/src/main/java/com/squareup/objectgraph/internal/codegen/AtInjectBinding.java
+++ b/core/src/main/java/com/squareup/objectgraph/internal/codegen/AtInjectBinding.java
@@ -98,7 +98,7 @@ final class AtInjectBinding extends Binding<Object> {
   }
 
   private static boolean hasAtInject(Element enclosed) {
-    return enclosed.getAnnotation(Inject.class) == null;
+    return enclosed.getAnnotation(Inject.class) != null;
   }
 
   @Override public void attach(Linker linker) {

--- a/core/src/main/java/com/squareup/objectgraph/internal/codegen/JavaWriter.java
+++ b/core/src/main/java/com/squareup/objectgraph/internal/codegen/JavaWriter.java
@@ -257,7 +257,7 @@ public final class JavaWriter {
   /**
    * Equivalent to {@code annotation(annotationType.getName(), attributes)}.
    */
-  public void annotation(Class<? extends Annotation> annotationType,Map<String, ?> attributes)
+  public void annotation(Class<? extends Annotation> annotationType, Map<String, ?> attributes)
       throws IOException {
     annotation(annotationType.getName(), attributes);
   }

--- a/core/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/core/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,4 +1,3 @@
 com.squareup.objectgraph.internal.codegen.InjectProcessor
 com.squareup.objectgraph.internal.codegen.ProvidesProcessor
-# TODO: Enable full graph processing.
-#com.squareup.objectgraph.internal.codegen.FullGraphProcessor
+com.squareup.objectgraph.internal.codegen.FullGraphProcessor

--- a/core/src/test/java/com/squareup/objectgraph/ChildModuleTest.java
+++ b/core/src/test/java/com/squareup/objectgraph/ChildModuleTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2012 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.objectgraph;
+
+import javax.inject.Inject;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+@SuppressWarnings("unused")
+public final class ChildModuleTest {
+  static class TestEntryPoint {
+    @Inject String s;
+  }
+
+  @Module(entryPoints = TestEntryPoint.class)
+  static class ModuleWithEntryPoint {
+  }
+
+  @Test public void childModuleWithEntryPoint() {
+    @Module(children = ModuleWithEntryPoint.class)
+    class TestModule {
+      @Provides String provideString() {
+        return "injected";
+      }
+    }
+
+    ObjectGraph objectGraph = ObjectGraph.get(new TestModule());
+    TestEntryPoint entryPoint = new TestEntryPoint();
+    objectGraph.inject(entryPoint);
+    assertThat(entryPoint.s).isEqualTo("injected");
+  }
+
+  static class TestStaticInjection {
+    @Inject static String s;
+  }
+
+  @Module(staticInjections = TestStaticInjection.class)
+  static class ModuleWithStaticInjection {
+  }
+
+  @Test public void childModuleWithStaticInjection() {
+    @Module(children = ModuleWithStaticInjection.class)
+    class TestModule {
+      @Provides String provideString() {
+        return "injected";
+      }
+    }
+
+    ObjectGraph objectGraph = ObjectGraph.get(new TestModule());
+    TestStaticInjection.s = null;
+    objectGraph.injectStatics();
+    assertThat(TestStaticInjection.s).isEqualTo("injected");
+  }
+
+  @Module
+  static class ModuleWithBinding {
+    @Provides String provideString() {
+      return "injected";
+    }
+  }
+
+  @Test public void childModuleWithBinding() {
+    class TestEntryPoint {
+      @Inject String s;
+    }
+
+    @Module(
+        entryPoints = TestEntryPoint.class,
+        children = ModuleWithBinding.class
+    )
+    class TestModule {
+    }
+
+    ObjectGraph objectGraph = ObjectGraph.get(new TestModule());
+    TestEntryPoint entryPoint = new TestEntryPoint();
+    objectGraph.inject(entryPoint);
+    assertThat(entryPoint.s).isEqualTo("injected");
+  }
+
+  @Module(children = ModuleWithBinding.class)
+  static class ModuleWithChildModule {
+  }
+
+  @Test public void childModuleWithChildModule() {
+    class TestEntryPoint {
+      @Inject String s;
+    }
+
+    @Module(
+        entryPoints = TestEntryPoint.class,
+        children = ModuleWithChildModule.class
+    )
+    class TestModule {
+    }
+
+    ObjectGraph objectGraph = ObjectGraph.get(new TestModule());
+    TestEntryPoint entryPoint = new TestEntryPoint();
+    objectGraph.inject(entryPoint);
+    assertThat(entryPoint.s).isEqualTo("injected");
+  }
+
+  @Module
+  static class ModuleWithConstructor {
+    private final String value;
+
+    ModuleWithConstructor(String value) {
+      this.value = value;
+    }
+
+    @Provides String provideString() {
+      return value;
+    }
+  }
+
+  @Test public void childModuleMissingManualConstruction() {
+    @Module(children = ModuleWithConstructor.class)
+    class TestModule {
+    }
+
+    try {
+      ObjectGraph.get(new TestModule());
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
+  @Test public void childModuleWithManualConstruction() {
+    class TestEntryPoint {
+      @Inject String s;
+    }
+
+    @Module(
+        entryPoints = TestEntryPoint.class,
+        children = ModuleWithConstructor.class
+    )
+    class TestModule {
+    }
+
+    ObjectGraph objectGraph = ObjectGraph.get(new ModuleWithConstructor("a"), new TestModule());
+    TestEntryPoint entryPoint = new TestEntryPoint();
+    objectGraph.inject(entryPoint);
+    assertThat(entryPoint.s).isEqualTo("a");
+  }
+}


### PR DESCRIPTION
This makes it possible for modular applications to declare
'complete' modules, which are the eligible for full-graph
analysis.
