### PR TITLE
Prefer code gen over annotations for Module.children.

### DIFF
--- a/core/src/main/java/com/squareup/objectgraph/internal/codegen/AtInjectBinding.java
+++ b/core/src/main/java/com/squareup/objectgraph/internal/codegen/AtInjectBinding.java
@@ -43,7 +43,12 @@ final class AtInjectBinding extends Binding<Object> {
     this.keys = keys;
   }
 
-  static AtInjectBinding create(TypeElement type) {
+  /**
+   * @param forMembersInjection true if the binding is being created to inject
+   *     members only. Such injections do not require {@code @Inject}
+   *     annotations.
+   */
+  static AtInjectBinding create(TypeElement type, boolean forMembersInjection) {
     List<String> requiredKeys = new ArrayList<String>();
     boolean hasInjectAnnotatedConstructor = false;
     boolean isConstructable = false;
@@ -76,12 +81,13 @@ final class AtInjectBinding extends Binding<Object> {
         break;
 
       default:
-        throw new IllegalArgumentException("Unexpected @Inject annotation on "
-            + enclosed.getSimpleName().toString());
+        if (hasAtInject(enclosed)) {
+          throw new IllegalArgumentException("Unexpected @Inject annotation on " + enclosed);
+        }
       }
     }
 
-    if (requiredKeys.isEmpty()) {
+    if (!hasInjectAnnotatedConstructor && requiredKeys.isEmpty() && !forMembersInjection) {
       throw new IllegalArgumentException("No injectable members on "
           + type.getQualifiedName().toString() + ". Do you want to add an injectable constructor?");
     }

--- a/core/src/main/java/com/squareup/objectgraph/internal/codegen/BuildTimeLinker.java
+++ b/core/src/main/java/com/squareup/objectgraph/internal/codegen/BuildTimeLinker.java
@@ -16,6 +16,7 @@
 package com.squareup.objectgraph.internal.codegen;
 
 import com.squareup.objectgraph.internal.Binding;
+import com.squareup.objectgraph.internal.Keys;
 import com.squareup.objectgraph.internal.Linker;
 import java.util.List;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -49,7 +50,7 @@ final class BuildTimeLinker extends Linker {
     if (type.getKind() == ElementKind.INTERFACE) {
       return null;
     }
-    return AtInjectBinding.create(type);
+    return AtInjectBinding.create(type, Keys.isMembersInjection(key));
   }
 
   @Override protected void reportErrors(List<String> errors) {

--- a/core/src/main/java/com/squareup/objectgraph/internal/codegen/CodeGen.java
+++ b/core/src/main/java/com/squareup/objectgraph/internal/codegen/CodeGen.java
@@ -26,6 +26,7 @@ import javax.lang.model.element.AnnotationValueVisitor;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.ArrayType;
@@ -222,5 +223,36 @@ final class CodeGen {
       default:
         throw new AssertionError();
     }
+  }
+
+  /**
+   * Returns the no-args constructor for {@code type}, or null if no such
+   * constructor exists.
+   */
+  public static ExecutableElement getNoArgsConstructor(TypeElement type) {
+    for (Element enclosed : type.getEnclosedElements()) {
+      if (enclosed.getKind() != ElementKind.CONSTRUCTOR) {
+        continue;
+      }
+      ExecutableElement constructor = (ExecutableElement) enclosed;
+      if (constructor.getParameters().isEmpty()) {
+        return constructor;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Returns true if generated code can invoke {@code constructor}. That is, if
+   * the constructor is non-private and its enclosing class is either a
+   * top-level class or a static nested class.
+   */
+  public static boolean isCallableConstructor(ExecutableElement constructor) {
+    if (constructor.getModifiers().contains(Modifier.PRIVATE)) {
+      return false;
+    }
+    TypeElement type = (TypeElement) constructor.getEnclosingElement();
+    return type.getEnclosingElement().getKind() == ElementKind.PACKAGE
+        || type.getModifiers().contains(Modifier.STATIC);
   }
 }


### PR DESCRIPTION
This reworks the ModuleAdapter class to also track a
reference to its module. Doing so makes it easier to
manage the module adapters and module instances.
