### PR TITLE
Add an option to exclude an activity or service as an entry point.

### DIFF
--- a/androidmanifest/src/main/java/com/squareup/objectgraph/androidmanifest/ModuleGenerator.java
+++ b/androidmanifest/src/main/java/com/squareup/objectgraph/androidmanifest/ModuleGenerator.java
@@ -46,7 +46,8 @@ import org.xml.sax.SAXException;
  * classes referenced in an {@code AndroidManifest.xml} file.
  */
 public final class ModuleGenerator {
-  private static final String NAMESPACE = "http://schemas.android.com/apk/res/android";
+  private static final String ANDROID_NS = "http://schemas.android.com/apk/res/android";
+  private static final String OBJECTGRAPH_NS = "http://github.com/square/objectgraph";
 
   /**
    * Returns the path of the generated ManifestModule.java for {@code manifest}.
@@ -135,9 +136,13 @@ public final class ModuleGenerator {
             || tagName.equals("provider")
             || tagName.equals("receiver")
             || tagName.equals("service")) {
-          Attr nameAttr = ee.getAttributeNodeNS(NAMESPACE, "name");
+          Attr nameAttr = ee.getAttributeNodeNS(ANDROID_NS, "name");
           if (nameAttr == null) {
             throw new IllegalArgumentException("Expected a name attribute on " + ee);
+          }
+          Attr entryPointAttr = ee.getAttributeNodeNS(OBJECTGRAPH_NS, "entryPoint");
+          if (entryPointAttr != null && !Boolean.valueOf(entryPointAttr.getValue())) {
+            continue;
           }
           result.add(nameAttr.getValue());
         }

--- a/androidmanifest/src/test/java/com/squareup/objectgraph/androidmanifest/ModuleGeneratorTest.java
+++ b/androidmanifest/src/test/java/com/squareup/objectgraph/androidmanifest/ModuleGeneratorTest.java
@@ -30,29 +30,6 @@ import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 public final class ModuleGeneratorTest {
-  private static final String MANIFEST_XML = ""
-      + "<manifest"
-      + "    xmlns:android=\"http://schemas.android.com/apk/res/android\"\n"
-      + "    package=\"com.squareup.badhorse\">\n"
-      + "  <uses-permission android:name=\"not.an.entry.point\"/>\n"
-      + "  <permission android:name=\"not.an.entry.point\"/>\n"
-      + "  <application android:name=\"not.an.entry.point\">\n"
-      + "    <uses-library android:name=\"not.an.entry.point\"/>\n"
-      + "    <activity android:name=\"result.a.Activity\">\n"
-      + "      <intent-filter>\n"
-      + "        <action android:name=\"not.an.entry.point\"/>\n"
-      + "        <category android:name=\"not.an.entry.point\"/>\n"
-      + "      </intent-filter>\n"
-      + "    </activity>\n"
-      + "    <provider android:name=\"result.b.Provider\"/>\n"
-      + "    <receiver android:name=\"result.c.Receiver\">\n"
-      + "      <intent-filter>\n"
-      + "        <action android:name=\"not.an.entry.point\"/>\n"
-      + "      </intent-filter>\n"
-      + "    </receiver>\n"
-      + "    <service android:name=\"result.d.Service\"/>\n"
-      + "  </application>\n"
-      + "</manifest>\n";
   private ModuleGenerator generator = new ModuleGenerator();
   private StringWriter stringWriter = new StringWriter();
 
@@ -93,9 +70,49 @@ public final class ModuleGeneratorTest {
   }
 
   @Test public void extractEntryPointNames() throws Exception {
-    Document document = document(MANIFEST_XML);
+    String manifestXml = ""
+        + "<manifest"
+        + "    xmlns:android=\"http://schemas.android.com/apk/res/android\"\n"
+        + "    package=\"com.squareup.badhorse\">\n"
+        + "  <uses-permission android:name=\"not.an.entry.point\"/>\n"
+        + "  <permission android:name=\"not.an.entry.point\"/>\n"
+        + "  <application android:name=\"not.an.entry.point\">\n"
+        + "    <uses-library android:name=\"not.an.entry.point\"/>\n"
+        + "    <activity android:name=\"result.a.Activity\">\n"
+        + "      <intent-filter>\n"
+        + "        <action android:name=\"not.an.entry.point\"/>\n"
+        + "        <category android:name=\"not.an.entry.point\"/>\n"
+        + "      </intent-filter>\n"
+        + "    </activity>\n"
+        + "    <provider android:name=\"result.b.Provider\"/>\n"
+        + "    <receiver android:name=\"result.c.Receiver\">\n"
+        + "      <intent-filter>\n"
+        + "        <action android:name=\"not.an.entry.point\"/>\n"
+        + "      </intent-filter>\n"
+        + "    </receiver>\n"
+        + "    <service android:name=\"result.d.Service\"/>\n"
+        + "  </application>\n"
+        + "</manifest>\n";
+    Document document = document(manifestXml);
     assertThat(generator.getNameReferences(document)).isEqualTo(Arrays.asList(
         "result.a.Activity", "result.b.Provider", "result.c.Receiver", "result.d.Service"));
+  }
+
+  @Test public void excludedEntryPointNames() throws Exception {
+    String manifestXml = ""
+        + "<manifest"
+        + "    xmlns:android=\"http://schemas.android.com/apk/res/android\"\n"
+        + "    xmlns:objectgraph=\"http://github.com/square/objectgraph\"\n"
+        + "    package=\"com.squareup.badhorse\">\n"
+        + "  <application>\n"
+        + "    <activity android:name=\"false.Activity\" objectgraph:entryPoint=\"false\"/>\n"
+        + "    <activity android:name=\"true.Activity\" objectgraph:entryPoint=\"true\"/>\n"
+        + "    <activity android:name=\"default.Activity\"/>\n"
+        + "  </application>\n"
+        + "</manifest>\n";
+    Document document = document(manifestXml);
+    assertThat(generator.getNameReferences(document))
+        .isEqualTo(Arrays.asList("true.Activity", "default.Activity"));
   }
 
   @Test public void generate() throws IOException {


### PR DESCRIPTION
This is useful in apps that have services that only work on certain
API levels. For example, a subclass of RemoteViewsService in an app
that supports Froyo devices.
