### PR TITLE
Add support for injecting a Lazy<T> from a binding of T

### DIFF
--- a/core/src/main/java/com/squareup/objectgraph/Lazy.java
+++ b/core/src/main/java/com/squareup/objectgraph/Lazy.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2012 Google, Inc.
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.objectgraph;
+
+/**
+ * A value that is lazily returned. A {@code Lazy<T>} creates or obtains its underlying
+ * value once, and caches that value thereafter.
+ * <p>
+ * Despite the similarity of these interfaces, {@code Lazy<T>} is semantically quite
+ * distinct from {@code Provider<T>} which provides a new value on each call.
+ */
+public interface Lazy<T> {
+  /**
+   * Return the underlying value, creating the value (once) if needed. Any two calls will
+   * return the same instance.
+   */
+  T get();
+}

--- a/core/src/main/java/com/squareup/objectgraph/internal/LazyBinding.java
+++ b/core/src/main/java/com/squareup/objectgraph/internal/LazyBinding.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2012 Google, Inc.
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.objectgraph.internal;
+
+import com.squareup.objectgraph.Lazy;
+
+/**
+ * Injects a Lazy wrapper for a type T
+ */
+final class LazyBinding<T> extends Binding<Lazy<T>> {
+
+  private final static Object NOT_PRESENT = new Object();
+
+  private final String lazyKey;
+  private Binding<T> delegate;
+
+  public LazyBinding(String key, Object requiredBy, String lazyKey) {
+    super(key, null, false, requiredBy);
+    this.lazyKey = lazyKey;
+  }
+
+  @SuppressWarnings("unchecked") // At runtime we know it's a Binding<Lazy<T>>.
+  @Override
+  public void attach(Linker linker) {
+    delegate = (Binding<T>) linker.requestBinding(lazyKey, requiredBy);
+  }
+
+  @Override public void injectMembers(Lazy<T> t) {
+    throw new UnsupportedOperationException(); // not a member injection binding.
+  }
+
+  @Override
+  public Lazy<T> get() {
+    return new Lazy<T>() {
+      private Object cacheValue = NOT_PRESENT;
+
+      @SuppressWarnings("unchecked") // Delegate is of type T
+      @Override
+      public T get() {
+        return (T) ((cacheValue != NOT_PRESENT) ? cacheValue : (cacheValue = delegate.get()));
+      }
+    };
+  }
+
+}

--- a/core/src/main/java/com/squareup/objectgraph/internal/Linker.java
+++ b/core/src/main/java/com/squareup/objectgraph/internal/Linker.java
@@ -117,20 +117,23 @@ public abstract class Linker {
   }
 
   /**
-   * Creates a just-in-time binding for the key in {@code deferred}. The type of
-   * binding to be created depends on the key's type:
+   * Creates a just-in-time binding for the key in {@code deferred}. The type of binding
+   * to be created depends on the key's type:
    * <ul>
-   *   <li>Injections of {@code Provider<Foo>} and {@code MembersInjector<Bar>}
-   *       will delegate to the bindings of {@code Foo} and {@code Bar}
-   *       respectively.
-   *   <li>Injections of other types will use the injectable constructors of
-   *       those classes.
+   *   <li>Injections of {@code Provider<Foo>}, {@code MembersInjector<Bar>}, and
+   *       {@code Lazy<Blah>} will delegate to the bindings of {@code Foo}, {@code Bar}, and
+   *       {@code Blah} respectively.
+   *   <li>Injections of other types will use the injectable constructors of those classes.
    * </ul>
    */
   private Binding<?> createJitBinding(String key, Object requiredBy) throws ClassNotFoundException {
-    String delegateKey = Keys.getDelegateKey(key);
-    if (delegateKey != null) {
-      return new BuiltInBinding<Object>(key, requiredBy, delegateKey);
+    String builtInBindingsKey = Keys.getBuiltInBindingsKey(key);
+    if (builtInBindingsKey != null) {
+      return new BuiltInBinding<Object>(key, requiredBy, builtInBindingsKey);
+    }
+    String lazyKey = Keys.getLazyKey(key);
+    if (lazyKey != null) {
+      return new LazyBinding<Object>(key, requiredBy, lazyKey);
     }
 
     String className = Keys.getClassName(key);

--- a/core/src/test/java/com/squareup/objectgraph/InjectionOfLazyTest.java
+++ b/core/src/test/java/com/squareup/objectgraph/InjectionOfLazyTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2012 Google Inc.
+ * Copyright (C) 2012 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.objectgraph;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests of injection of Lazy<T> bindings.
+ */
+public final class InjectionOfLazyTest {
+  @Test public void lazyValueCreation() {
+    final AtomicInteger counter = new AtomicInteger();
+    class TestEntryPoint {
+      @Inject Lazy<Integer> i;
+      @Inject Lazy<Integer> j;
+    }
+
+    @Module(entryPoints = TestEntryPoint.class)
+    class TestModule {
+      @Provides Integer provideInteger() {
+        return counter.incrementAndGet();
+      }
+    }
+
+    TestEntryPoint ep = injectWithModule(new TestEntryPoint(), new TestModule());
+    assertEquals(0, counter.get());
+    assertEquals(1, ep.i.get().intValue());
+    assertEquals(1, counter.get());
+    assertEquals(2, ep.j.get().intValue());
+    assertEquals(1, ep.i.get().intValue());
+    assertEquals(2, counter.get());
+  }
+
+  @Test public void lazyNullCreation() {
+    final AtomicInteger provideCounter = new AtomicInteger(0);
+    class TestEntryPoint {
+      @Inject Lazy<String> i;
+    }
+    @Module(entryPoints = TestEntryPoint.class)
+    class TestModule {
+      @Provides String provideInteger() {
+        provideCounter.incrementAndGet();
+        return null;
+      }
+    }
+
+    TestEntryPoint ep = injectWithModule(new TestEntryPoint(), new TestModule());
+    assertEquals(0, provideCounter.get());
+    assertNull(ep.i.get());
+    assertEquals(1, provideCounter.get());
+    assertNull(ep.i.get()); // still null
+    assertEquals(1, provideCounter.get()); // still only called once.
+  }
+
+  @Test public void providerOfLazyOfSomething() {
+    final AtomicInteger counter = new AtomicInteger();
+    class TestEntryPoint {
+      @Inject Provider<Lazy<Integer>> providerOfLazyInteger;
+    }
+
+    @Module(entryPoints = TestEntryPoint.class)
+    class TestModule {
+      @Provides Integer provideInteger() {
+        return counter.incrementAndGet();
+      }
+    }
+
+    TestEntryPoint ep = injectWithModule(new TestEntryPoint(), new TestModule());
+    assertEquals(0, counter.get());
+    Lazy<Integer> i = ep.providerOfLazyInteger.get();
+    assertEquals(1, i.get().intValue());
+    assertEquals(1, counter.get());
+    assertEquals(1, i.get().intValue());
+    Lazy<Integer> j = ep.providerOfLazyInteger.get();
+    assertEquals(2, j.get().intValue());
+    assertEquals(2, counter.get());
+    assertEquals(1, i.get().intValue());
+  }
+
+  @Test public void sideBySideLazyVsProvider() {
+    final AtomicInteger counter = new AtomicInteger();
+    class TestEntryPoint {
+      @Inject Provider<Integer> providerOfInteger;
+      @Inject Lazy<Integer> lazyInteger;
+    }
+
+    @Module(entryPoints = TestEntryPoint.class)
+    class TestModule {
+      @Provides Integer provideInteger() {
+        return counter.incrementAndGet();
+      }
+    }
+
+    TestEntryPoint ep = injectWithModule(new TestEntryPoint(), new TestModule());
+    assertEquals(0, counter.get());
+    assertEquals(0, counter.get());
+    assertEquals(1, ep.lazyInteger.get().intValue());
+    assertEquals(1, counter.get());
+    assertEquals(2, ep.providerOfInteger.get().intValue()); // fresh instance
+    assertEquals(1, ep.lazyInteger.get().intValue()); // still the same instance
+    assertEquals(2, counter.get());
+    assertEquals(3, ep.providerOfInteger.get().intValue()); // fresh instance
+    assertEquals(1, ep.lazyInteger.get().intValue()); // still the same instance.
+  }
+
+  private <T> T injectWithModule(T ep, Object ... modules) {
+    // TODO(cgruber): Make og.inject(foo) return foo properly.
+    ObjectGraph og = ObjectGraph.get(modules);
+    og.inject(ep);
+    return ep;
+  }
+
+}

--- a/core/src/test/java/com/squareup/objectgraph/internal/KeysTest.java
+++ b/core/src/test/java/com/squareup/objectgraph/internal/KeysTest.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.objectgraph.internal;
 
+import com.squareup.objectgraph.Lazy;
 import com.squareup.objectgraph.MembersInjector;
 import java.lang.reflect.Field;
 import java.util.List;
@@ -89,22 +90,39 @@ public final class KeysTest {
   Provider<String> providerOfType;
   String providedType;
   @Test public void testGetDelegateKey() throws NoSuchFieldException {
-    assertThat(Keys.getDelegateKey(fieldKey("providerOfType")))
+    assertThat(Keys.getBuiltInBindingsKey(fieldKey("providerOfType")))
         .isEqualTo(fieldKey("providedType"));
   }
 
   @Named("/@") Provider<String> providerOfTypeAnnotated;
   @Named("/@") String providedTypeAnnotated;
   @Test public void testGetDelegateKeyWithAnnotation() throws NoSuchFieldException {
-    assertThat(Keys.getDelegateKey(fieldKey("providerOfTypeAnnotated")))
+    assertThat(Keys.getBuiltInBindingsKey(fieldKey("providerOfTypeAnnotated")))
         .isEqualTo(fieldKey("providedTypeAnnotated"));
   }
 
   @Named("/@") MembersInjector<String> membersInjectorOfType;
   @Named("/@") String injectedType;
   @Test public void testGetDelegateKeyWithMembersInjector() throws NoSuchFieldException {
-    assertThat(Keys.getDelegateKey(fieldKey("membersInjectorOfType")))
+    assertThat(Keys.getBuiltInBindingsKey(fieldKey("membersInjectorOfType")))
         .isEqualTo("members/java.lang.String");
+  }
+
+  @Named("/@") Lazy<String> lazyAnnotatedString;
+  @Named("/@") String eagerAnnotatedString;
+  @Test public void testAnnotatedGetLazyKey() throws NoSuchFieldException {
+    assertThat(Keys.getLazyKey(fieldKey("lazyAnnotatedString")))
+        .isEqualTo(fieldKey("eagerAnnotatedString"));
+  }
+
+  Lazy<String> lazyString;
+  String eagerString;
+  @Test public void testGetLazyKey() throws NoSuchFieldException {
+    assertThat(Keys.getLazyKey(fieldKey("lazyString"))).isEqualTo(fieldKey("eagerString"));
+  }
+
+  @Test public void testGetLazyKey_WrongKeyType() throws NoSuchFieldException {
+    assertThat(Keys.getLazyKey(fieldKey("providerOfTypeAnnotated"))).isNull();
   }
 
   private String fieldKey(String fieldName) throws NoSuchFieldException {


### PR DESCRIPTION
This change adds a Lazy<T> wrapper type, semantically different from Provider<T>, in that it (explicitly) lazily creates a single value, and caches it once.  This can be done for lazy singleton creation on the fly, or other values.

If the Lazy<T> is a singleton, then the first one will cause it to be created, but the same Lazy<T> will be injected everywhere.  If it is not a singleton then a new Lazy<T> will be created at each injection point. 

The current version doesn't address concurrency issues, though it probably should. 
