### PR TITLE
Rename Module's property children to includes

### DIFF
--- a/core/src/main/java/com/squareup/objectgraph/Module.java
+++ b/core/src/main/java/com/squareup/objectgraph/Module.java
@@ -38,11 +38,18 @@ public @interface Module {
   boolean overrides() default false;
 
   /**
-   * Additional {@code @Module}-annotated classes that this module is composed
-   * of. The contributions of the modules in {@code children}, and of their
-   * children recursively, are all contributed to the object graph.
+   * @deprecated Use module includes vs. children
    */
+  @Deprecated
   Class<?>[] children() default { };
+
+  /**
+   * Additional {@code @Module}-annotated classes from which this module is
+   * composed. The de-duplicated contributions of the modules in
+   * {@code includes}, and of their inclusions recursively, are all contributed
+   * to the object graph.
+   */
+  Class<?>[] includes() default { };
 
   /**
    * True if all of the bindings required by this module can also be satisfied

--- a/core/src/main/java/com/squareup/objectgraph/ObjectGraph.java
+++ b/core/src/main/java/com/squareup/objectgraph/ObjectGraph.java
@@ -15,6 +15,10 @@
  */
 package com.squareup.objectgraph;
 
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import com.squareup.objectgraph.internal.Binding;
 import com.squareup.objectgraph.internal.Keys;
 import com.squareup.objectgraph.internal.Linker;
@@ -23,9 +27,6 @@ import com.squareup.objectgraph.internal.ProblemDetector;
 import com.squareup.objectgraph.internal.RuntimeLinker;
 import com.squareup.objectgraph.internal.StaticInjection;
 import com.squareup.objectgraph.internal.UniqueMap;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 /**
  * A graph of objects linked by their dependencies.
@@ -122,7 +123,7 @@ public final class ObjectGraph {
   }
 
   /**
-   * Returns a full set of module adapters, including module adapters for child
+   * Returns a full set of module adapters, including module adapters for included
    * modules.
    */
   private static ModuleAdapter<?>[] getAllModuleAdapters(Object[] seedModules) {
@@ -145,7 +146,7 @@ public final class ObjectGraph {
     // Next add adapters for the modules that we need to construct. This creates
     // instances of modules as necessary.
     for (ModuleAdapter<?> adapter : seedAdapters) {
-      collectChildModulesRecursively(adapter, adaptersByModuleType);
+      collectIncludedodulesRecursively(adapter, adaptersByModuleType);
     }
 
     return adaptersByModuleType.values().toArray(
@@ -153,16 +154,16 @@ public final class ObjectGraph {
   }
 
   /**
-   * Fills {@code result} with the module adapters for the children of {@code
-   * adapter}, and their children recursively.
+   * Fills {@code result} with the module adapters for the includes of {@code
+   * adapter}, and their includes recursively.
    */
-  private static void collectChildModulesRecursively(ModuleAdapter<?> adapter,
+  private static void collectIncludedodulesRecursively(ModuleAdapter<?> adapter,
       Map<Class<?>, ModuleAdapter<?>> result) {
-    for (Class<?> child : adapter.children) {
-      if (!result.containsKey(child)) {
-        ModuleAdapter<Object> childAdapter = ModuleAdapter.get(child, null);
-        result.put(child, childAdapter);
-        collectChildModulesRecursively(childAdapter, result);
+    for (Class<?> include : adapter.includes) {
+      if (!result.containsKey(include)) {
+        ModuleAdapter<Object> includedModuleAdapter = ModuleAdapter.get(include, null);
+        result.put(include, includedModuleAdapter);
+        collectIncludedodulesRecursively(includedModuleAdapter, result);
       }
     }
   }

--- a/core/src/main/java/com/squareup/objectgraph/internal/ModuleAdapter.java
+++ b/core/src/main/java/com/squareup/objectgraph/internal/ModuleAdapter.java
@@ -15,14 +15,15 @@
  */
 package com.squareup.objectgraph.internal;
 
-import com.squareup.objectgraph.Module;
-import com.squareup.objectgraph.ObjectGraph;
-import com.squareup.objectgraph.Provides;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import com.squareup.objectgraph.Module;
+import com.squareup.objectgraph.ObjectGraph;
+import com.squareup.objectgraph.Provides;
 
 /**
  * Extracts bindings from an {@code @Module}-annotated class.
@@ -33,16 +34,16 @@ public abstract class ModuleAdapter<T> {
   public final String[] entryPoints;
   public final Class<?>[] staticInjections;
   public final boolean overrides;
-  public final Class<?>[] children;
+  public final Class<?>[] includes;
   public final boolean complete;
   protected T module;
 
   protected ModuleAdapter(String[] entryPoints, Class<?>[] staticInjections, boolean overrides,
-      Class<?>[] children, boolean complete) {
+      Class<?>[] includes, boolean complete) {
     this.entryPoints = entryPoints;
     this.staticInjections = staticInjections;
     this.overrides = overrides;
-    this.children = children;
+    this.includes = includes;
     this.complete = complete;
   }
 
@@ -91,10 +92,33 @@ public abstract class ModuleAdapter<T> {
   static class ReflectiveModuleAdapter extends ModuleAdapter<Object> {
     final Class<?> moduleClass;
 
+    @SuppressWarnings("deprecation") // explicitly handles deprecated case
     ReflectiveModuleAdapter(Class<?> moduleClass, Module annotation) {
-      super(toMemberKeys(annotation.entryPoints()), annotation.staticInjections(),
-          annotation.overrides(), annotation.children(), annotation.complete());
+      super(toMemberKeys(
+          annotation.entryPoints()),
+          annotation.staticInjections(),
+          annotation.overrides(),
+          concatenate(annotation.includes(), annotation.children()),
+          annotation.complete());
       this.moduleClass = moduleClass;
+    }
+
+    /**
+     * A class that returns the concatenation of two {@code Class<T>[]}s.
+     *
+     * TODO(cgruber): Remove this method when module children are removed.
+     *
+     * @deprecated this method exists only to support a legacy deprecation case
+     */
+    @Deprecated
+    private static Class<?>[] concatenate(Class<?>[] first, Class<?>[] second) {
+      if (second == null || second.length == 0) {
+        return first;
+      }
+      final Class<?>[] result = new Class<?>[second.length + first.length];
+      System.arraycopy(second, 0, result, 0, second.length);
+      System.arraycopy(first, 0, result, second.length, first.length);
+      return result;
     }
 
     private static String[] toMemberKeys(Class<?>[] entryPoints) {
@@ -125,9 +149,9 @@ public abstract class ModuleAdapter<T> {
 
     @Override protected Object newModule() {
       try {
-        Constructor<?> childConstructor = moduleClass.getDeclaredConstructor();
-        childConstructor.setAccessible(true);
-        return childConstructor.newInstance();
+        Constructor<?> includeConstructor = moduleClass.getDeclaredConstructor();
+        includeConstructor.setAccessible(true);
+        return includeConstructor.newInstance();
       } catch (Exception e) {
         throw new IllegalArgumentException("Unable to instantiate " + moduleClass.getName(), e);
       }

--- a/core/src/main/java/com/squareup/objectgraph/internal/codegen/ArrayUtil.java
+++ b/core/src/main/java/com/squareup/objectgraph/internal/codegen/ArrayUtil.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2012 Google, Inc.
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.objectgraph.internal.codegen;
+
+
+/**
+ * A utility to provide Array utilities above and beyond what are provided in the
+ * java.util.Arrays class.
+ */
+class ArrayUtil {
+  /**
+   * A class that returns the concatenation of two {@code Class<T>[]}s.
+   *
+   * TODO(cgruber): Remove this method when module children are removed if no other callers.
+   *
+   * @deprecated this method exists only to support a legacy deprecation case
+   */
+  @Deprecated
+  static Object[] concatenate(Object[] first, Object[] second) {
+    if (second == null || second.length == 0) {
+      return first;
+    } else if (first == null || first.length == 0) {
+      return second;
+    }
+    final Object[] result = new Object[second.length + first.length];
+    System.arraycopy(second, 0, result, 0, second.length);
+    System.arraycopy(first, 0, result, second.length, first.length);
+    return result;
+  }
+}

--- a/example/src/main/java/coffee/DripCoffeeModule.java
+++ b/example/src/main/java/coffee/DripCoffeeModule.java
@@ -1,17 +1,16 @@
 package coffee;
 
-import com.squareup.objectgraph.Module;
-import com.squareup.objectgraph.Provides;
 import javax.inject.Singleton;
 
+import com.squareup.objectgraph.Module;
+import com.squareup.objectgraph.Provides;
+
 @Module(
-    entryPoints = CoffeeApp.class
+    entryPoints = CoffeeApp.class,
+    includes = PumpModule.class
 )
 class DripCoffeeModule {
   @Provides @Singleton Heater provideHeater() {
     return new ElectricHeater();
-  }
-  @Provides Pump providePump(Thermosiphon pump) {
-    return pump;
   }
 }

--- a/example/src/main/java/coffee/PumpModule.java
+++ b/example/src/main/java/coffee/PumpModule.java
@@ -1,0 +1,11 @@
+package coffee;
+
+import com.squareup.objectgraph.Module;
+import com.squareup.objectgraph.Provides;
+
+@Module(complete = false)
+class PumpModule {
+  @Provides Pump providePump(Thermosiphon pump) {
+    return pump;
+  }
+}


### PR DESCRIPTION
Rename Module's property children to includes, and generally rename all internals to reflect this, leaving children in place but deprecated pending conversion of all callers.
