### PR TITLE
Rename Module's property children to includes

### DIFF
--- a/core/src/main/java/com/squareup/objectgraph/Module.java
+++ b/core/src/main/java/com/squareup/objectgraph/Module.java
@@ -38,11 +38,18 @@ public @interface Module {
   boolean overrides() default false;
 
   /**
-   * Additional {@code @Module}-annotated classes that this module is composed
-   * of. The contributions of the modules in {@code children}, and of their
-   * children recursively, are all contributed to the object graph.
+   * @deprecated Use module includes vs. children
    */
+  @Deprecated
   Class<?>[] children() default { };
+
+  /**
+   * Additional {@code @Module}-annotated classes from which this module is
+   * composed. The de-duplicated contributions of the modules in
+   * {@code includes}, and of their inclusions recursively, are all contributed
+   * to the object graph.
+   */
+  Class<?>[] includes() default { };
 
   /**
    * True if all of the bindings required by this module can also be satisfied

--- a/core/src/main/java/com/squareup/objectgraph/ObjectGraph.java
+++ b/core/src/main/java/com/squareup/objectgraph/ObjectGraph.java
@@ -122,7 +122,7 @@ public final class ObjectGraph {
   }
 
   /**
-   * Returns a full set of module adapters, including module adapters for child
+   * Returns a full set of module adapters, including module adapters for included
    * modules.
    */
   private static ModuleAdapter<?>[] getAllModuleAdapters(Object[] seedModules) {
@@ -145,7 +145,7 @@ public final class ObjectGraph {
     // Next add adapters for the modules that we need to construct. This creates
     // instances of modules as necessary.
     for (ModuleAdapter<?> adapter : seedAdapters) {
-      collectChildModulesRecursively(adapter, adaptersByModuleType);
+      collectIncludedModulesRecursively(adapter, adaptersByModuleType);
     }
 
     return adaptersByModuleType.values().toArray(
@@ -153,16 +153,16 @@ public final class ObjectGraph {
   }
 
   /**
-   * Fills {@code result} with the module adapters for the children of {@code
-   * adapter}, and their children recursively.
+   * Fills {@code result} with the module adapters for the includes of {@code
+   * adapter}, and their includes recursively.
    */
-  private static void collectChildModulesRecursively(ModuleAdapter<?> adapter,
+  private static void collectIncludedModulesRecursively(ModuleAdapter<?> adapter,
       Map<Class<?>, ModuleAdapter<?>> result) {
-    for (Class<?> child : adapter.children) {
-      if (!result.containsKey(child)) {
-        ModuleAdapter<Object> childAdapter = ModuleAdapter.get(child, null);
-        result.put(child, childAdapter);
-        collectChildModulesRecursively(childAdapter, result);
+    for (Class<?> include : adapter.includes) {
+      if (!result.containsKey(include)) {
+        ModuleAdapter<Object> includedModuleAdapter = ModuleAdapter.get(include, null);
+        result.put(include, includedModuleAdapter);
+        collectIncludedModulesRecursively(includedModuleAdapter, result);
       }
     }
   }

--- a/core/src/main/java/com/squareup/objectgraph/internal/codegen/ArrayUtil.java
+++ b/core/src/main/java/com/squareup/objectgraph/internal/codegen/ArrayUtil.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2012 Google, Inc.
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.objectgraph.internal.codegen;
+
+
+/**
+ * A utility to provide Array utilities above and beyond what are provided in the
+ * java.util.Arrays class.
+ */
+class ArrayUtil {
+  /**
+   * A class that returns the concatenation of two {@code Class<T>[]}s.
+   *
+   * TODO(cgruber): Remove this method when module children are removed if no other callers.
+   *
+   * @deprecated this method exists only to support a legacy deprecation case
+   */
+  @Deprecated
+  static Object[] concatenate(Object[] first, Object[] second) {
+    final Object[] result = new Object[second.length + first.length];
+    System.arraycopy(second, 0, result, 0, second.length);
+    System.arraycopy(first, 0, result, second.length, first.length);
+    return result;
+  }
+}

--- a/core/src/test/java/com/squareup/objectgraph/ModuleIncludesTest.java
+++ b/core/src/test/java/com/squareup/objectgraph/ModuleIncludesTest.java
@@ -22,7 +22,7 @@ import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 @SuppressWarnings("unused")
-public final class ChildModuleTest {
+public final class ModuleIncludesTest {
   static class TestEntryPoint {
     @Inject String s;
   }
@@ -32,7 +32,7 @@ public final class ChildModuleTest {
   }
 
   @Test public void childModuleWithEntryPoint() {
-    @Module(children = ModuleWithEntryPoint.class)
+    @Module(includes = ModuleWithEntryPoint.class)
     class TestModule {
       @Provides String provideString() {
         return "injected";
@@ -54,7 +54,7 @@ public final class ChildModuleTest {
   }
 
   @Test public void childModuleWithStaticInjection() {
-    @Module(children = ModuleWithStaticInjection.class)
+    @Module(includes = ModuleWithStaticInjection.class)
     class TestModule {
       @Provides String provideString() {
         return "injected";
@@ -81,7 +81,7 @@ public final class ChildModuleTest {
 
     @Module(
         entryPoints = TestEntryPoint.class,
-        children = ModuleWithBinding.class
+        includes = ModuleWithBinding.class
     )
     class TestModule {
     }
@@ -92,7 +92,7 @@ public final class ChildModuleTest {
     assertThat(entryPoint.s).isEqualTo("injected");
   }
 
-  @Module(children = ModuleWithBinding.class)
+  @Module(includes = ModuleWithBinding.class)
   static class ModuleWithChildModule {
   }
 
@@ -103,7 +103,7 @@ public final class ChildModuleTest {
 
     @Module(
         entryPoints = TestEntryPoint.class,
-        children = ModuleWithChildModule.class
+        includes = ModuleWithChildModule.class
     )
     class TestModule {
     }
@@ -128,7 +128,7 @@ public final class ChildModuleTest {
   }
 
   @Test public void childModuleMissingManualConstruction() {
-    @Module(children = ModuleWithConstructor.class)
+    @Module(includes = ModuleWithConstructor.class)
     class TestModule {
     }
 
@@ -146,7 +146,7 @@ public final class ChildModuleTest {
 
     @Module(
         entryPoints = TestEntryPoint.class,
-        children = ModuleWithConstructor.class
+        includes = ModuleWithConstructor.class
     )
     class TestModule {
     }
@@ -156,4 +156,48 @@ public final class ChildModuleTest {
     objectGraph.inject(entryPoint);
     assertThat(entryPoint.s).isEqualTo("a");
   }
+
+  // Legacy Tests //
+
+  @Test public void childrenButNoIncludes() {
+    class TestEntryPoint {
+      @Inject String s;
+    }
+    @Module(entryPoints = TestEntryPoint.class, children = ModuleWithBinding.class)
+    class TestModule {
+    }
+
+    TestEntryPoint ep = injectWithModule(new TestEntryPoint(), new TestModule());
+    assertThat(ep.s).isEqualTo("injected");
+  }
+
+  @Module(complete = false)
+  static class ModuleWithInteger {
+    @Provides Integer provideString() { return 1; }
+  }
+
+  @Test public void bothIncludesAndChildren() {
+    class TestEntryPoint {
+      @Inject String s;
+      @Inject Integer i;
+    }
+    @Module(
+        entryPoints = TestEntryPoint.class,
+        includes = ModuleWithInteger.class,
+        children = ModuleWithBinding.class)
+    class TestModule {
+    }
+
+    TestEntryPoint ep = injectWithModule(new TestEntryPoint(), new TestModule());
+    assertThat(ep.s).isEqualTo("injected");
+    assertThat(ep.i).isEqualTo(1);
+  }
+
+  private <T> T injectWithModule(T ep, Object ... modules) {
+    // TODO(cgruber): Make og.inject(foo) return foo properly.
+    ObjectGraph og = ObjectGraph.get(modules);
+    og.inject(ep);
+    return ep;
+  }
+
 }

--- a/example/src/main/java/coffee/DripCoffeeModule.java
+++ b/example/src/main/java/coffee/DripCoffeeModule.java
@@ -5,13 +5,11 @@ import com.squareup.objectgraph.Provides;
 import javax.inject.Singleton;
 
 @Module(
-    entryPoints = CoffeeApp.class
+    entryPoints = CoffeeApp.class,
+    includes = PumpModule.class
 )
 class DripCoffeeModule {
   @Provides @Singleton Heater provideHeater() {
     return new ElectricHeater();
-  }
-  @Provides Pump providePump(Thermosiphon pump) {
-    return pump;
   }
 }

--- a/example/src/main/java/coffee/PumpModule.java
+++ b/example/src/main/java/coffee/PumpModule.java
@@ -1,0 +1,11 @@
+package coffee;
+
+import com.squareup.objectgraph.Module;
+import com.squareup.objectgraph.Provides;
+
+@Module(complete = false)
+class PumpModule {
+  @Provides Pump providePump(Thermosiphon pump) {
+    return pump;
+  }
+}


### PR DESCRIPTION
Rename Module's property children to includes, and generally rename all internals to reflect this, leaving @ Module(children=...) present but deprecated until all callers can be migrated. 
