### PR TITLE
Add support for bindings of `@Provides @Element Foo provideFoo() {...}`

### DIFF
--- a/core/src/main/java/dagger/Element.java
+++ b/core/src/main/java/dagger/Element.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2012 Google Inc.
+ * Copyright (C) 2012 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dagger;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotates a {@code @Provides}-marked method of a {@code @Module} class such
+ * that it contributes its value to a multi-value binding. The method's return
+ * type forms the generic type argument of a {@code Set<T>}, and the returned
+ * value is contributed to the set. The object graph will pass dependencies to
+ * the method as parameters. The {@code Set<T>} produced from the accumulation
+ * of values will be immutable.
+ *
+ * @author Christian Gruber
+ */
+@Documented @Target(METHOD) @Retention(RUNTIME)
+public @interface Element {
+
+}

--- a/core/src/main/java/dagger/internal/Keys.java
+++ b/core/src/main/java/dagger/internal/Keys.java
@@ -22,6 +22,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Set;
 import javax.inject.Provider;
 import javax.inject.Qualifier;
 
@@ -42,6 +43,7 @@ public final class Keys {
   private static final String PROVIDER_PREFIX = Provider.class.getName() + "<";
   private static final String MEMBERS_INJECTOR_PREFIX = MembersInjector.class.getName() + "<";
   private static final String LAZY_PREFIX = Lazy.class.getName() + "<";
+  private static final String SET_PREFIX = Set.class.getName() + "<";
 
   private static final LruCache<Class<? extends Annotation>, Boolean> IS_QUALIFIER_ANNOTATION
       = new LruCache<Class<? extends Annotation>, Boolean>(Integer.MAX_VALUE) {
@@ -67,17 +69,34 @@ public final class Keys {
   /** Returns a key for {@code type} annotated by {@code annotation}. */
   public static String get(Type type, Annotation annotation) {
     type = boxIfPrimitive(type);
-    if (annotation == null
-        && type instanceof Class
-        && !((Class<?>) type).isArray()) {
+    if (annotation == null && type instanceof Class && !((Class<?>) type).isArray()) {
       return ((Class<?>) type).getName();
     }
-
     StringBuilder result = new StringBuilder();
     if (annotation != null) {
       result.append(annotation).append("/");
     }
     typeToString(type, result);
+    return result.toString();
+  }
+
+  /**
+   * Returns a key for {@code type} annotated with {@code annotations},
+   * wrapped by {@code Set}, reporting failures against {@code subject}.
+   *
+   * @param annotations the annotations on a single method, field or parameter.
+   *     This array may contain at most one qualifier annotation.
+   */
+  public static String getElementKey(Type type, Annotation[] annotations, Object subject) {
+    Annotation qualifier = extractQualifier(annotations, subject);
+    type = boxIfPrimitive(type);
+    StringBuilder result = new StringBuilder();
+    if (qualifier != null) {
+      result.append(qualifier).append("/");
+    }
+    result.append(SET_PREFIX);
+    typeToString(type, result);
+    result.append(">");
     return result.toString();
   }
 
@@ -89,6 +108,15 @@ public final class Keys {
    *     This array may contain at most one qualifier annotation.
    */
   public static String get(Type type, Annotation[] annotations, Object subject) {
+    return get(type, extractQualifier(annotations, subject));
+  }
+
+  /**
+   * Validates that among {@code annotations} there exists only one annotation which is, itself
+   * qualified by {@code \@Qualifier}
+   */
+  private static Annotation extractQualifier(Annotation[] annotations,
+      Object subject) {
     Annotation qualifier = null;
     for (Annotation a : annotations) {
       if (!IS_QUALIFIER_ANNOTATION.get(a.annotationType())) {
@@ -99,7 +127,7 @@ public final class Keys {
       }
       qualifier = a;
     }
-    return get(type, qualifier);
+    return qualifier;
   }
 
   private static void typeToString(Type type, StringBuilder result) {

--- a/core/src/main/java/dagger/internal/SetBinding.java
+++ b/core/src/main/java/dagger/internal/SetBinding.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2012 Google, Inc.
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dagger.internal;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * A {@code Binding<T>} which contains contributors (other bindings marked with
+ * {@code @Provides} {@code @Element}), to which it delegates provision
+ * requests on an as-needed basis.
+ */
+final class SetBinding<T> extends Binding<Set<T>> {
+  private final Set<Binding<?>> contributors = new LinkedHashSet<Binding<?>>();
+
+  public SetBinding(String key) {
+    super(key, null, false, null);
+  }
+
+  @Override public void attach(Linker linker) {
+    for (Binding<?> contributor : contributors) {
+      contributor.attach(linker);
+    }
+  }
+
+  @Override public Set<T> get() {
+    Set<T> result = new LinkedHashSet<T>(contributors.size());
+    for (Binding<?> contributor : contributors) {
+      result.add((T) contributor.get()); // Let runtime exceptions through.
+    }
+    return Collections.unmodifiableSet(result);
+  }
+
+  @Override public String toString() {
+    return "SetBinding" + contributors;
+  }
+
+  public void add(Binding<?> binding) {
+    contributors.add(binding);
+  }
+}

--- a/core/src/main/java/dagger/internal/codegen/ProvidesProcessor.java
+++ b/core/src/main/java/dagger/internal/codegen/ProvidesProcessor.java
@@ -106,6 +106,12 @@ public final class ProvidesProcessor extends AbstractProcessor {
         continue;
       }
 
+      if (providerMethod.getAnnotation(dagger.Element.class) != null) {
+        error("@Element binding not supported with code generation: "
+            + type.getQualifiedName() + "." + providerMethod);
+        continue;
+      }
+
       List<ExecutableElement> methods = result.get(type);
       if (methods == null) {
         methods = new ArrayList<ExecutableElement>();

--- a/core/src/test/java/dagger/SetBindingTest.java
+++ b/core/src/test/java/dagger/SetBindingTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2012 Google Inc.
+ * Copyright (C) 2012 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dagger;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public final class SetBindingTest {
+  @Test public void multiValueBindings_SingleModule() {
+    class TestEntryPoint {
+      @Inject Set<String> strings;
+    }
+
+    @Module(entryPoints = TestEntryPoint.class)
+    class TestModule {
+      @Provides @Element String provideFirstString() { return "string1"; }
+      @Provides @Element String provideSecondString() { return "string2"; }
+    }
+
+    TestEntryPoint ep = injectWithModule(new TestEntryPoint(), new TestModule());
+    assertEquals(set("string1", "string2"), ep.strings);
+  }
+
+  @Test public void multiValueBindings_MultiModule() {
+    class TestEntryPoint {
+      @Inject Set<String> strings;
+    }
+
+    @Module
+    class TestChildModule {
+      @Provides @Element String provideSecondString() { return "string2"; }
+    }
+
+    @Module(entryPoints = TestEntryPoint.class, children = TestChildModule.class)
+    class TestModule {
+      @Provides @Element String provideFirstString() { return "string1"; }
+    }
+
+    TestEntryPoint ep = injectWithModule(new TestEntryPoint(),
+        new TestModule(), new TestChildModule());
+    assertEquals(set("string1", "string2"), ep.strings);
+  }
+
+  @Test public void multiValueBindings_WithSingletonAndDefaultValues() {
+    final AtomicInteger singletonCounter = new AtomicInteger(100);
+    final AtomicInteger defaultCounter = new AtomicInteger(200);
+    class TestEntryPoint {
+      @Inject Set<Integer> objects1;
+      @Inject Set<Integer> objects2;
+    }
+
+    @Module(entryPoints = TestEntryPoint.class)
+    class TestModule {
+      @Provides @Element @Singleton Integer a() { return singletonCounter.getAndIncrement(); }
+      @Provides @Element Integer b() { return defaultCounter.getAndIncrement(); }
+    }
+
+    TestEntryPoint ep = injectWithModule(new TestEntryPoint(), new TestModule());
+    assertEquals(set(100, 200), ep.objects1);
+    assertEquals(set(100, 201), ep.objects2);
+  }
+
+  @Test public void multiValueBindings_WithSingletonsAcrossMultipleEntryPoints() {
+    final AtomicInteger singletonCounter = new AtomicInteger(100);
+    final AtomicInteger defaultCounter = new AtomicInteger(200);
+    class TestEntryPoint1 {
+      @Inject Set<Integer> objects1;
+    }
+    class TestEntryPoint2 {
+      @Inject Set<Integer> objects2;
+    }
+
+    @Module(entryPoints = { TestEntryPoint1.class, TestEntryPoint2.class })
+    class TestModule {
+      @Provides @Element @Singleton Integer a() { return singletonCounter.getAndIncrement(); }
+      @Provides @Element Integer b() { return defaultCounter.getAndIncrement(); }
+    }
+
+    ObjectGraph graph = ObjectGraph.get(new TestModule());
+    TestEntryPoint1 ep1 = new TestEntryPoint1();
+    graph.inject(ep1);
+    TestEntryPoint2 ep2 = new TestEntryPoint2();
+    graph.inject(ep2);
+    assertEquals(set(100, 200), ep1.objects1);
+    assertEquals(set(100, 201), ep2.objects2);
+
+ }
+
+  @Test public void multiValueBindings_WithQualifiers() {
+    class TestEntryPoint {
+      @Inject Set<String> strings;
+      @Inject @Named("foo") Set<String> fooStrings;
+    }
+
+    @Module(entryPoints = TestEntryPoint.class)
+    class TestModule {
+      @Provides @Element String provideString1() { return "string1"; }
+      @Provides @Element String provideString2() { return "string2"; }
+      @Provides @Element @Named("foo") String provideString3() { return "string3"; }
+      @Provides @Element @Named("foo") String provideString4() { return "string4"; }
+    }
+
+    TestEntryPoint ep = injectWithModule(new TestEntryPoint(), new TestModule());
+    assertEquals(set("string1", "string2"), ep.strings);
+    assertEquals(set("string4", "string3"), ep.fooStrings);
+  }
+
+  // TODO(cgruber): Move this into an example project.
+  @Test public void sampleMultiBindingLogger() {
+    class TestEntryPoint {
+      @Inject Logger logger;
+      public void doStuff() {
+        Throwable t = new NullPointerException("Naughty Naughty");
+        this.logger.log("Logging an error", t);
+      }
+    }
+
+    final AtomicReference<String> logoutput = new AtomicReference<String>();
+    @Module
+    class LogModule {
+      @Provides @Element LogSink outputtingLogSink() {
+        return new LogSink() {
+          @Override public void log(LogMessage message) {
+            StringWriter sw = new StringWriter();
+            message.error.printStackTrace(new PrintWriter(sw));
+            logoutput.set(message.message + "\n" + sw.getBuffer().toString());
+          }
+        };
+      }
+    }
+    @Module(entryPoints = TestEntryPoint.class)
+    class TestModule {
+      @Provides @Element LogSink nullLogger() {
+        return new LogSink() { @Override public void log(LogMessage message) {} };
+      }
+    }
+
+    TestEntryPoint ep = injectWithModule(new TestEntryPoint(),new TestModule(), new LogModule());
+    assertNull(logoutput.get());
+    ep.doStuff();
+    assertNotNull(logoutput.get());
+    assertThat(logoutput.get()).contains("Naughty Naughty");
+    assertThat(logoutput.get()).contains("NullPointerException");
+  }
+
+  static class Logger {
+    @Inject Set<LogSink> loggers;
+    public void log(String text, Throwable error) {
+      LogMessage m = new LogMessage(text, error);
+      for (LogSink sink : loggers) {
+        sink.log(m);
+      }
+    }
+  }
+
+  static class LogMessage {
+    public final String message;
+    public final Throwable error;
+    public LogMessage (String message, Throwable error) {
+      this.message = message;
+      this.error = error;
+    }
+  }
+
+  static interface LogSink {
+    void log(LogMessage message);
+  }
+
+  private <T> T injectWithModule(T ep, Object ... modules) {
+    // TODO(cgruber): Make og.inject(foo) return foo properly.
+    ObjectGraph og = ObjectGraph.get(modules);
+    og.inject(ep);
+    return ep;
+  }
+
+  private <T> Set<T> set(T... ts) {
+    return new LinkedHashSet<T>(Arrays.asList(ts));
+  }
+
+}

--- a/core/src/test/java/dagger/internal/KeysTest.java
+++ b/core/src/test/java/dagger/internal/KeysTest.java
@@ -15,9 +15,12 @@
  */
 package dagger.internal;
 
+import dagger.Element;
 import dagger.Lazy;
 import dagger.MembersInjector;
+import dagger.Provides;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 import javax.inject.Named;
@@ -125,8 +128,26 @@ public final class KeysTest {
     assertThat(Keys.getLazyKey(fieldKey("providerOfTypeAnnotated"))).isNull();
   }
 
+  @Provides @Element String elementProvides() { return "foo"; }
+
+  @Test public void testGetElementKey_NoQualifier() throws NoSuchMethodException {
+    Method method = KeysTest.class.getDeclaredMethod("elementProvides", new Class<?>[]{});
+    assertThat(Keys.getElementKey(method.getGenericReturnType(), method.getAnnotations(), method))
+        .isEqualTo("java.util.Set<java.lang.String>");
+  }
+
+  @Named("foo")
+  @Provides @Element String qualifiedElementProvides() { return "foo"; }
+
+  @Test public void testGetElementKey_WithQualifier() throws NoSuchMethodException {
+    Method method = KeysTest.class.getDeclaredMethod("qualifiedElementProvides", new Class<?>[]{});
+    assertThat(Keys.getElementKey(method.getGenericReturnType(), method.getAnnotations(), method))
+        .isEqualTo("@javax.inject.Named(value=foo)/java.util.Set<java.lang.String>");
+  }
+
   private String fieldKey(String fieldName) throws NoSuchFieldException {
     Field field = KeysTest.class.getDeclaredField(fieldName);
     return Keys.get(field.getGenericType(), field.getAnnotations(), field);
   }
+
 }


### PR DESCRIPTION
This change provides "Set bindings".  This pull request is mostly for comment.  I need to flesh out the tests, and make sure we're covering some important cases, and that the behaviour is documented in the README.

Current functionality (with spaces to avoid tagging people on github)

``` java
@Module public class MyModule {
  @Provides @Element String provideString1() { return "String1"; }
  @Provides @Element String provideString2() { return "String2"; }
}
```

will allow someone to do

```
  ...
  @ Inject Set<String> strings;
  ...
```

Each item is bound when the Set is bound, and elements within can be singleton, or one-per-injection, depending on whether the `@Provides @Element` method is singleton or not.   It's a bit of a straw man and we want to do the same for `@MapEntry(key="foo")` or some such also.  

This change should also allow for

``` java
@Module public class MyModule {
  @Provides @Element String provideString1() { return "String1"; }
  @Provides @Element String provideString2() { return "String2"; }
  @Provides @Element @MyQualifier String provideString3() { return "String3"; }
  @Provides @Element @MyQualifier String provideString4() { return "String4"; }
}
```

to create two Set bindings - one keyed `"java.util.Set<java.lang.String>"` and one keyed as `"@com.foo.MyQualifier/java.util.Set<java.lang.String>"`, each containing two elements.  

Examples of usage:
- plugin architectures riding on top of a managed object space
- command-line flag bindings systems
- No-op broadcast/listen functionality with extra modules providing extension.
