### PR TITLE
Rename Element to OneOf

### DIFF
--- a/core/src/main/java/dagger/OneOf.java
+++ b/core/src/main/java/dagger/OneOf.java
@@ -34,6 +34,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @author Christian Gruber
  */
 @Documented @Target(METHOD) @Retention(RUNTIME)
-public @interface Element {
+public @interface OneOf {
 
 }

--- a/core/src/main/java/dagger/internal/ModuleAdapter.java
+++ b/core/src/main/java/dagger/internal/ModuleAdapter.java
@@ -17,7 +17,7 @@
 package dagger.internal;
 
 
-import dagger.Element;
+import dagger.OneOf;
 import dagger.Module;
 import dagger.ObjectGraph;
 import dagger.Provides;
@@ -119,7 +119,7 @@ public abstract class ModuleAdapter<T> {
         for (Method method : c.getDeclaredMethods()) {
           if (method.isAnnotationPresent(Provides.class)) {
             String key = Keys.get(method.getGenericReturnType(), method.getAnnotations(), method);
-            if (method.isAnnotationPresent(Element.class)) {
+            if (method.isAnnotationPresent(OneOf.class)) {
               handleSetBindings(bindings, method, key);
             } else {
               handleBindings(bindings, method, key);

--- a/core/src/main/java/dagger/internal/SetBinding.java
+++ b/core/src/main/java/dagger/internal/SetBinding.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 /**
  * A {@code Binding<T>} which contains contributors (other bindings marked with
- * {@code @Provides} {@code @Element}), to which it delegates provision
+ * {@code @Provides} {@code @OneOf}), to which it delegates provision
  * requests on an as-needed basis.
  */
 public final class SetBinding<T> extends Binding<Set<T>> {

--- a/core/src/main/java/dagger/internal/codegen/FullGraphProcessor.java
+++ b/core/src/main/java/dagger/internal/codegen/FullGraphProcessor.java
@@ -16,6 +16,7 @@
 package dagger.internal.codegen;
 
 import dagger.Module;
+import dagger.OneOf;
 import dagger.Provides;
 import dagger.internal.Binding;
 import dagger.internal.Linker;
@@ -86,7 +87,7 @@ public final class FullGraphProcessor extends AbstractProcessor {
         ExecutableElement providerMethod = (ExecutableElement) enclosed;
         String key = GeneratorKeys.get(providerMethod);
         ProviderMethodBinding binding = new ProviderMethodBinding(key, providerMethod);
-        if (providerMethod.getAnnotation(dagger.Element.class) != null) {
+        if (providerMethod.getAnnotation(OneOf.class) != null) {
           String elementKey = GeneratorKeys.getElementKey(providerMethod);
           SetBinding.add(addTo, elementKey, binding);
         } else {

--- a/core/src/main/java/dagger/internal/codegen/ProvidesProcessor.java
+++ b/core/src/main/java/dagger/internal/codegen/ProvidesProcessor.java
@@ -16,6 +16,7 @@
 package dagger.internal.codegen;
 
 import dagger.Module;
+import dagger.OneOf;
 import dagger.Provides;
 import dagger.internal.Binding;
 import dagger.internal.Linker;
@@ -199,7 +200,7 @@ public final class ProvidesProcessor extends AbstractProcessor {
     writer.annotation(Override.class);
     writer.beginMethod("void", "getBindings", PUBLIC, BINDINGS_MAP, "map");
     for (ExecutableElement providerMethod : providerMethods) {
-      if (providerMethod.getAnnotation(dagger.Element.class) != null) {
+      if (providerMethod.getAnnotation(OneOf.class) != null) {
         String key = GeneratorKeys.getElementKey(providerMethod);
         writer.statement("SetBinding.add(map, %s, new %s(module))", JavaWriter.stringLiteral(key),
             providerMethod.getSimpleName().toString() + "Binding");

--- a/core/src/test/java/dagger/SetBindingTest.java
+++ b/core/src/test/java/dagger/SetBindingTest.java
@@ -41,8 +41,8 @@ public final class SetBindingTest {
 
     @Module(entryPoints = TestEntryPoint.class)
     class TestModule {
-      @Provides @Element String provideFirstString() { return "string1"; }
-      @Provides @Element String provideSecondString() { return "string2"; }
+      @Provides @OneOf String provideFirstString() { return "string1"; }
+      @Provides @OneOf String provideSecondString() { return "string2"; }
     }
 
     TestEntryPoint ep = injectWithModule(new TestEntryPoint(), new TestModule());
@@ -56,12 +56,12 @@ public final class SetBindingTest {
 
     @Module
     class TestIncludesModule {
-      @Provides @Element String provideSecondString() { return "string2"; }
+      @Provides @OneOf String provideSecondString() { return "string2"; }
     }
 
     @Module(entryPoints = TestEntryPoint.class, includes = TestIncludesModule.class)
     class TestModule {
-      @Provides @Element String provideFirstString() { return "string1"; }
+      @Provides @OneOf String provideFirstString() { return "string1"; }
     }
 
     TestEntryPoint ep = injectWithModule(new TestEntryPoint(),
@@ -79,8 +79,8 @@ public final class SetBindingTest {
 
     @Module(entryPoints = TestEntryPoint.class)
     class TestModule {
-      @Provides @Element @Singleton Integer a() { return singletonCounter.getAndIncrement(); }
-      @Provides @Element Integer b() { return defaultCounter.getAndIncrement(); }
+      @Provides @OneOf @Singleton Integer a() { return singletonCounter.getAndIncrement(); }
+      @Provides @OneOf Integer b() { return defaultCounter.getAndIncrement(); }
     }
 
     TestEntryPoint ep = injectWithModule(new TestEntryPoint(), new TestModule());
@@ -100,8 +100,8 @@ public final class SetBindingTest {
 
     @Module(entryPoints = { TestEntryPoint1.class, TestEntryPoint2.class })
     class TestModule {
-      @Provides @Element @Singleton Integer a() { return singletonCounter.getAndIncrement(); }
-      @Provides @Element Integer b() { return defaultCounter.getAndIncrement(); }
+      @Provides @OneOf @Singleton Integer a() { return singletonCounter.getAndIncrement(); }
+      @Provides @OneOf Integer b() { return defaultCounter.getAndIncrement(); }
     }
 
     ObjectGraph graph = ObjectGraph.get(new TestModule());
@@ -122,10 +122,10 @@ public final class SetBindingTest {
 
     @Module(entryPoints = TestEntryPoint.class)
     class TestModule {
-      @Provides @Element String provideString1() { return "string1"; }
-      @Provides @Element String provideString2() { return "string2"; }
-      @Provides @Element @Named("foo") String provideString3() { return "string3"; }
-      @Provides @Element @Named("foo") String provideString4() { return "string4"; }
+      @Provides @OneOf String provideString1() { return "string1"; }
+      @Provides @OneOf String provideString2() { return "string2"; }
+      @Provides @OneOf @Named("foo") String provideString3() { return "string3"; }
+      @Provides @OneOf @Named("foo") String provideString4() { return "string4"; }
     }
 
     TestEntryPoint ep = injectWithModule(new TestEntryPoint(), new TestModule());
@@ -146,7 +146,7 @@ public final class SetBindingTest {
     final AtomicReference<String> logoutput = new AtomicReference<String>();
     @Module
     class LogModule {
-      @Provides @Element LogSink outputtingLogSink() {
+      @Provides @OneOf LogSink outputtingLogSink() {
         return new LogSink() {
           @Override public void log(LogMessage message) {
             StringWriter sw = new StringWriter();
@@ -158,7 +158,7 @@ public final class SetBindingTest {
     }
     @Module(entryPoints = TestEntryPoint.class)
     class TestModule {
-      @Provides @Element LogSink nullLogger() {
+      @Provides @OneOf LogSink nullLogger() {
         return new LogSink() { @Override public void log(LogMessage message) {} };
       }
     }

--- a/core/src/test/java/dagger/internal/KeysTest.java
+++ b/core/src/test/java/dagger/internal/KeysTest.java
@@ -15,7 +15,7 @@
  */
 package dagger.internal;
 
-import dagger.Element;
+import dagger.OneOf;
 import dagger.Lazy;
 import dagger.MembersInjector;
 import dagger.Provides;
@@ -128,7 +128,7 @@ public final class KeysTest {
     assertThat(Keys.getLazyKey(fieldKey("providerOfTypeAnnotated"))).isNull();
   }
 
-  @Provides @Element String elementProvides() { return "foo"; }
+  @Provides @OneOf String elementProvides() { return "foo"; }
 
   @Test public void testGetElementKey_NoQualifier() throws NoSuchMethodException {
     Method method = KeysTest.class.getDeclaredMethod("elementProvides", new Class<?>[]{});
@@ -137,7 +137,7 @@ public final class KeysTest {
   }
 
   @Named("foo")
-  @Provides @Element String qualifiedElementProvides() { return "foo"; }
+  @Provides @OneOf String qualifiedElementProvides() { return "foo"; }
 
   @Test public void testGetElementKey_WithQualifier() throws NoSuchMethodException {
     Method method = KeysTest.class.getDeclaredMethod("qualifiedElementProvides", new Class<?>[]{});


### PR DESCRIPTION
We're striving for a better name.  OneOf helps to indicate that this is contributing to a set, and its slightly different name helps differentiate from app-specified annotations.
