### PR TITLE
Updating dagger-androidmanifest-plugin Maven packaging 

### DIFF
--- a/androidmanifest/pom.xml
+++ b/androidmanifest/pom.xml
@@ -26,7 +26,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dagger-androidmanifest-plugin</artifactId>
-    <packaging>jar</packaging>
+    <packaging>maven-plugin</packaging>
     <name>Dagger AndroidManifest.xml Module Generator</name>
 
     <dependencies>


### PR DESCRIPTION
The packaging of the `dagger-androidmanifest-plugin` maven plugin is currently `jar`.

When I added the plugin as specified in `README.md`, the Maven build failed with the following error :

```
No plugin descriptor found at META-INF/maven/plugin.xml
```

Changing the packaging from `jar` to `maven-plugin` solves this issue.

I'm not sure why it was `jar` in the first place, maybe I missed some point.
