### PR TITLE
Fixing maven typo in Readme

### DIFF
--- a/androidmanifest/README.md
+++ b/androidmanifest/README.md
@@ -18,7 +18,7 @@ Maven Usage
     <execution>
       <phase>generate-sources</phase>
       <goals>
-        <goal>generate</goals>
+        <goal>generate</goal>
       </goals>
     </execution>
   </executions>


### PR DESCRIPTION
Typo in the maven conf in Readme.md

Maybe that was intentional to prevent dirty copy & paste ;-) ?
