### PR TITLE
Make ObjectGraph.get() lazy and remove getLazy().

### DIFF
--- a/core/src/test/java/dagger/InjectionTest.java
+++ b/core/src/test/java/dagger/InjectionTest.java
@@ -241,8 +241,9 @@ public final class InjectionTest {
     class TestModule {
     }
 
+    ObjectGraph graph = ObjectGraph.get(new TestModule());
     try {
-      ObjectGraph.get(new TestModule());
+      graph.validate();
       fail();
     } catch (IllegalArgumentException expected) {
     }
@@ -384,8 +385,9 @@ public final class InjectionTest {
     class TestModule {
     }
 
+    ObjectGraph graph = ObjectGraph.get(new TestModule());
     try {
-      ObjectGraph.get(new TestModule());
+      graph.validate();
       fail();
     } catch (IllegalArgumentException expected) {
     }
@@ -400,8 +402,9 @@ public final class InjectionTest {
     class TestModule {
     }
 
+    ObjectGraph graph = ObjectGraph.get(new TestModule());
     try {
-      ObjectGraph.get(new TestModule());
+      graph.validate();
       fail();
     } catch (IllegalArgumentException expected) {
     }
@@ -490,8 +493,9 @@ public final class InjectionTest {
       }
     }
 
+    ObjectGraph graph = ObjectGraph.get(new TestModule());
     try {
-      ObjectGraph.get(new TestModule());
+      graph.validate();
       fail();
     } catch (IllegalArgumentException expected) {
     }

--- a/core/src/test/java/dagger/LazyInjectionTest.java
+++ b/core/src/test/java/dagger/LazyInjectionTest.java
@@ -26,7 +26,7 @@ public final class LazyInjectionTest {
     class TestModule {
     }
 
-    ObjectGraph.getLazy(new TestModule());
+    ObjectGraph.get(new TestModule());
     assertThat(lazyEntryPointLoaded).isFalse();
   }
 
@@ -45,7 +45,7 @@ public final class LazyInjectionTest {
       }
     }
 
-    ObjectGraph.getLazy(new TestModule());
+    ObjectGraph.get(new TestModule());
     assertThat(lazyProvidesParameterLoaded).isFalse();
   }
 
@@ -64,7 +64,7 @@ public final class LazyInjectionTest {
       }
     }
 
-    ObjectGraph.getLazy(new TestModule());
+    ObjectGraph.get(new TestModule());
     assertThat(lazyProvidesResultLoaded).isFalse();
   }
 
@@ -80,7 +80,7 @@ public final class LazyInjectionTest {
     class TestModule {
     }
 
-    ObjectGraph.getLazy(new TestModule());
+    ObjectGraph.get(new TestModule());
     assertThat(LazyInjectStaticsLoaded).isFalse();
   }
 
@@ -106,7 +106,7 @@ public final class LazyInjectionTest {
       }
     }
 
-    ObjectGraph objectGraph = ObjectGraph.getLazy(new TestModule());
+    ObjectGraph objectGraph = ObjectGraph.get(new TestModule());
     TestEntryPoint entryPoint = new TestEntryPoint();
     objectGraph.inject(entryPoint);
     assertThat(entryPoint.injected).isEqualTo("5");

--- a/core/src/test/java/dagger/MembersInjectorTest.java
+++ b/core/src/test/java/dagger/MembersInjectorTest.java
@@ -90,8 +90,9 @@ public final class MembersInjectorTest {
     class TestModule {
     }
 
+    ObjectGraph graph = ObjectGraph.get(new TestModule());
     try {
-      ObjectGraph.get(new TestModule());
+      graph.inject(new TestEntryPoint());
       fail();
     } catch (IllegalArgumentException expected) {
     }
@@ -106,8 +107,9 @@ public final class MembersInjectorTest {
     class TestModule {
     }
 
+    ObjectGraph graph = ObjectGraph.get(new TestModule());
     try {
-      ObjectGraph.get(new TestModule());
+      graph.inject(new TestEntryPoint());
       fail();
     } catch (IllegalArgumentException expected) {
     }
@@ -122,8 +124,9 @@ public final class MembersInjectorTest {
     class TestModule {
     }
 
+    ObjectGraph graph = ObjectGraph.get(new TestModule());
     try {
-      ObjectGraph.get(new TestModule());
+      graph.inject(new TestEntryPoint());
       fail();
     } catch (IllegalArgumentException expected) {
     }
@@ -170,8 +173,9 @@ public final class MembersInjectorTest {
     class TestModule {
     }
 
+    ObjectGraph graph = ObjectGraph.get(new TestModule());
     try {
-      ObjectGraph.get(new TestModule());
+      graph.inject(new TestEntryPoint());
       fail();
     } catch (IllegalArgumentException expected) {
     }

--- a/core/src/test/java/dagger/ProblemDetectorTest.java
+++ b/core/src/test/java/dagger/ProblemDetectorTest.java
@@ -32,7 +32,7 @@ public final class ProblemDetectorTest {
 
     ObjectGraph graph = ObjectGraph.get(new TestModule());
     try {
-      graph.detectProblems();
+      graph.validate();
       fail();
     } catch (RuntimeException expected) {
     }


### PR DESCRIPTION
The current API permits three levels of validation:
- getLazy : no validation
- get : graph validation
- detectProblems : graph validation + circular dependency checking

This folds together get and detectProblems as a single method "validate".
It gives getLazy the better name.
