### PR TITLE
Use a bitfield for Binding.linked and Binding.singleton.

### DIFF
--- a/core/src/main/java/dagger/ObjectGraph.java
+++ b/core/src/main/java/dagger/ObjectGraph.java
@@ -229,7 +229,7 @@ public final class ObjectGraph {
           + ". You must explicitly add an entry point to one of your modules.");
     }
     Binding<?> binding = linker.requestBinding(key, moduleClass);
-    if (binding == null || !binding.linked) {
+    if (binding == null || !binding.isLinked()) {
       linker.linkRequested();
       binding = linker.requestBinding(key, moduleClass);
     }

--- a/core/src/main/java/dagger/internal/Binding.java
+++ b/core/src/main/java/dagger/internal/Binding.java
@@ -25,17 +25,22 @@ import javax.inject.Provider;
 public class Binding<T> implements Provider<T>, MembersInjector<T> {
   public static final Binding<Object> UNRESOLVED = new Binding<Object>(null, null, false, null);
 
+  /** Set if the provided instance is always the same object. */
+  private static final int SINGLETON = 1 << 0;
+
+  /** Set if this binding's {@link #attach} completed without any missing dependencies. */
+  private static final int LINKED = 1 << 1;
+
   /** The key used to provide instances of 'T', or null if this binding cannot provide instances. */
   public final String provideKey;
 
   /** The key used to inject members of 'T', or null if this binding cannot inject members. */
   public final String membersKey;
 
-  /** True if the provided instance is always the same object. */
-  public final boolean singleton;
+  /** Bitfield of states like SINGLETON and LINKED. */
+  private int bits;
 
   public final Object requiredBy;
-  public boolean linked;
 
   protected Binding(String provideKey, String membersKey, boolean singleton, Object requiredBy) {
     if (singleton && provideKey == null) {
@@ -43,7 +48,7 @@ public class Binding<T> implements Provider<T>, MembersInjector<T> {
     }
     this.provideKey = provideKey;
     this.membersKey = membersKey;
-    this.singleton = singleton;
+    this.bits = (singleton ? SINGLETON : 0);
     this.requiredBy = requiredBy;
   }
 
@@ -74,5 +79,17 @@ public class Binding<T> implements Provider<T>, MembersInjector<T> {
    */
   public void getDependencies(Set<Binding<?>> getBindings, Set<Binding<?>> injectMembersBindings) {
     throw new UnsupportedOperationException(getClass().getName());
+  }
+
+  void setLinked() {
+    bits |= LINKED;
+  }
+
+  public boolean isLinked() {
+    return (bits & LINKED) != 0;
+  }
+
+  boolean isSingleton() {
+    return (bits & SINGLETON) != 0;
   }
 }

--- a/core/src/main/java/dagger/internal/Linker.java
+++ b/core/src/main/java/dagger/internal/Linker.java
@@ -62,7 +62,7 @@ public abstract class Linker {
    */
   public final Collection<Binding<?>> linkAll() {
     for (Binding<?> binding : bindings.values()) {
-      if (!binding.linked) {
+      if (!binding.isLinked()) {
         toLink.add(binding);
       }
     }
@@ -102,7 +102,7 @@ public abstract class Linker {
         attachSuccess = true;
         binding.attach(this);
         if (attachSuccess) {
-          binding.linked = true;
+          binding.setLinked();
         } else {
           toLink.add(binding);
         }
@@ -169,7 +169,7 @@ public abstract class Linker {
       return null;
     }
 
-    if (!binding.linked) {
+    if (!binding.isLinked()) {
       toLink.add(binding); // This binding was never linked; link it now!
     }
 
@@ -194,7 +194,7 @@ public abstract class Linker {
    * Returns a scoped binding for {@code binding}.
    */
   static <T> Binding<T> scope(final Binding<T> binding) {
-    if (!binding.singleton) {
+    if (!binding.isSingleton()) {
       return binding;
     }
     if (binding instanceof SingletonBinding) throw new AssertionError();

--- a/core/src/main/java/dagger/internal/codegen/CodeGen.java
+++ b/core/src/main/java/dagger/internal/codegen/CodeGen.java
@@ -130,11 +130,11 @@ final class CodeGen {
         }
         return null;
       }
-      @Override public Void visitPrimitive(PrimitiveType primitiveType, Void aVoid) {
+      @Override public Void visitPrimitive(PrimitiveType primitiveType, Void v) {
         result.append(box((PrimitiveType) type).getName());
         return null;
       }
-      @Override public Void visitArray(ArrayType arrayType, Void aVoid) {
+      @Override public Void visitArray(ArrayType arrayType, Void v) {
         typeToString(arrayType.getComponentType(), result, innerClassSeparator);
         result.append("[]");
         return null;
@@ -142,8 +142,9 @@ final class CodeGen {
       @Override public Void visitTypeVariable(TypeVariable typeVariable, Void v) {
         return null;
       }
-      @Override protected Void defaultAction(TypeMirror typeMirror, Void aVoid) {
-        throw new UnsupportedOperationException("Unexpected type " + typeMirror);
+      @Override protected Void defaultAction(TypeMirror typeMirror, Void v) {
+        throw new UnsupportedOperationException(
+            "Unexpected TypeKind " + typeMirror.getKind() + " for "  + typeMirror);
       }
     }, null);
   }


### PR DESCRIPTION
On its own, this is an unnecessary optimization. But I'm
planning on reworking ObjectGraph.verify() to require
additional state on each binding, and I don't want to
increase the memory footprint of all bindings for fields
that will rarely be used.
