### PR TITLE
Make Lazy work with ObjectGraph.validate().

### DIFF
--- a/core/src/main/java/dagger/internal/LazyBinding.java
+++ b/core/src/main/java/dagger/internal/LazyBinding.java
@@ -17,6 +17,7 @@
 package dagger.internal;
 
 import dagger.Lazy;
+import java.util.Set;
 
 /**
  * Injects a Lazy wrapper for a type T
@@ -56,4 +57,8 @@ final class LazyBinding<T> extends Binding<Lazy<T>> {
     };
   }
 
+  @Override public void getDependencies(
+      Set<Binding<?>> getBindings, Set<Binding<?>> injectMembersBindings) {
+    // We don't add 'delegate' because it isn't actually used by get() or injectMembers().
+  }
 }

--- a/core/src/test/java/dagger/ProblemDetectorTest.java
+++ b/core/src/test/java/dagger/ProblemDetectorTest.java
@@ -57,6 +57,21 @@ public final class ProblemDetectorTest {
     }
   }
 
+  @Test public void validateLazy() {
+    @Module
+    class TestModule {
+      @Provides Integer dependOnLazy(Lazy<String> lazyString) {
+        throw new AssertionError();
+      }
+      @Provides String provideLazyValue() {
+        throw new AssertionError();
+      }
+    }
+
+    ObjectGraph graph = ObjectGraph.get(new TestModule());
+    graph.validate();
+  }
+
   static class Rock {
     @Inject Scissors scissors;
   }


### PR DESCRIPTION
We weren't overriding getDependencies(), which caused
validate to fail with fire.
