### PR TITLE
Don't require entry point classes to have @Inject annotations.

### DIFF
--- a/core/src/main/java/dagger/ObjectGraph.java
+++ b/core/src/main/java/dagger/ObjectGraph.java
@@ -167,7 +167,7 @@ public final class ObjectGraph {
 
   private void linkEntryPoints() {
     for (Map.Entry<String, Class<?>> entry : entryPoints.entrySet()) {
-      linker.requestBinding(entry.getKey(), entry.getValue());
+      linker.requestEntryPoint(entry.getKey(), entry.getValue());
     }
   }
 

--- a/core/src/main/java/dagger/internal/AtInjectBinding.java
+++ b/core/src/main/java/dagger/internal/AtInjectBinding.java
@@ -135,11 +135,10 @@ final class AtInjectBinding<T> extends Binding<T> {
   }
 
   /**
-   * @param forMembersInjection true if the binding is being created to inject
-   *     members only. Such injections do not require {@code @Inject}
+   * @param mustBeInjectable true if the binding must have {@code @Inject}
    *     annotations.
    */
-  public static <T> Binding<T> create(Class<T> type, boolean forMembersInjection) {
+  public static <T> Binding<T> create(Class<T> type, boolean mustBeInjectable) {
     boolean singleton = type.isAnnotationPresent(Singleton.class);
     List<String> keys = new ArrayList<String>();
 
@@ -170,7 +169,7 @@ final class AtInjectBinding<T> extends Binding<T> {
       injectedConstructor = constructor;
     }
     if (injectedConstructor == null) {
-      if (injectedFields.isEmpty() && !forMembersInjection) {
+      if (injectedFields.isEmpty() && mustBeInjectable) {
         throw new IllegalArgumentException("No injectable members on " + type.getName()
             + ". Do you want to add an injectable constructor?");
       }

--- a/core/src/main/java/dagger/internal/RuntimeLinker.java
+++ b/core/src/main/java/dagger/internal/RuntimeLinker.java
@@ -23,8 +23,8 @@ import java.util.List;
  * and falls back to reflection.
  */
 public final class RuntimeLinker extends Linker {
-  @Override protected Binding<?> createAtInjectBinding(String key, String className)
-      throws ClassNotFoundException {
+  @Override protected Binding<?> createAtInjectBinding(
+      String key, String className, boolean mustBeInjectable) throws ClassNotFoundException {
     try {
       Class<?> c = Class.forName(className + "$InjectAdapter");
       Constructor<?> constructor = c.getConstructor();
@@ -40,7 +40,7 @@ public final class RuntimeLinker extends Linker {
       return null;
     }
 
-    return AtInjectBinding.create(c, Keys.isMembersInjection(key));
+    return AtInjectBinding.create(c, mustBeInjectable);
   }
 
   @Override protected void reportErrors(List<String> errors) {
@@ -52,6 +52,6 @@ public final class RuntimeLinker extends Linker {
     for (String error : errors) {
       message.append("\n  ").append(error);
     }
-    throw new IllegalArgumentException(message.toString());
+    throw new IllegalStateException(message.toString());
   }
 }

--- a/core/src/main/java/dagger/internal/codegen/AtInjectBinding.java
+++ b/core/src/main/java/dagger/internal/codegen/AtInjectBinding.java
@@ -44,11 +44,10 @@ final class AtInjectBinding extends Binding<Object> {
   }
 
   /**
-   * @param forMembersInjection true if the binding is being created to inject
-   *     members only. Such injections do not require {@code @Inject}
+   * @param mustBeInjectable true if the binding must have {@code @Inject}
    *     annotations.
    */
-  static AtInjectBinding create(TypeElement type, boolean forMembersInjection) {
+  static AtInjectBinding create(TypeElement type, boolean mustBeInjectable) {
     List<String> requiredKeys = new ArrayList<String>();
     boolean hasInjectAnnotatedConstructor = false;
     boolean isConstructable = false;
@@ -87,7 +86,7 @@ final class AtInjectBinding extends Binding<Object> {
       }
     }
 
-    if (!hasInjectAnnotatedConstructor && requiredKeys.isEmpty() && !forMembersInjection) {
+    if (!hasInjectAnnotatedConstructor && requiredKeys.isEmpty() && mustBeInjectable) {
       throw new IllegalArgumentException("No injectable members on "
           + type.getQualifiedName().toString() + ". Do you want to add an injectable constructor?");
     }

--- a/core/src/main/java/dagger/internal/codegen/BuildTimeLinker.java
+++ b/core/src/main/java/dagger/internal/codegen/BuildTimeLinker.java
@@ -16,7 +16,6 @@
 package dagger.internal.codegen;
 
 import dagger.internal.Binding;
-import dagger.internal.Keys;
 import dagger.internal.Linker;
 import java.util.List;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -39,7 +38,8 @@ final class BuildTimeLinker extends Linker {
     this.moduleName = moduleName;
   }
 
-  @Override protected Binding<?> createAtInjectBinding(String key, String className) {
+  @Override protected Binding<?> createAtInjectBinding(
+      String key, String className, boolean mustBeInjectable) {
     String sourceClassName = className.replace('$', '.');
     TypeElement type = processingEnv.getElementUtils().getTypeElement(sourceClassName);
     if (type == null) {
@@ -52,7 +52,7 @@ final class BuildTimeLinker extends Linker {
     if (type.getKind() == ElementKind.INTERFACE) {
       return null;
     }
-    return AtInjectBinding.create(type, Keys.isMembersInjection(key));
+    return AtInjectBinding.create(type, mustBeInjectable);
   }
 
   @Override protected void reportErrors(List<String> errors) {

--- a/core/src/test/java/dagger/InjectionTest.java
+++ b/core/src/test/java/dagger/InjectionTest.java
@@ -247,7 +247,7 @@ public final class InjectionTest {
     try {
       graph.validate();
       fail();
-    } catch (IllegalArgumentException expected) {
+    } catch (IllegalStateException expected) {
     }
   }
 
@@ -391,7 +391,7 @@ public final class InjectionTest {
     try {
       graph.validate();
       fail();
-    } catch (IllegalArgumentException expected) {
+    } catch (IllegalStateException expected) {
     }
   }
 
@@ -408,7 +408,7 @@ public final class InjectionTest {
     try {
       graph.validate();
       fail();
-    } catch (IllegalArgumentException expected) {
+    } catch (IllegalStateException expected) {
     }
   }
 
@@ -499,7 +499,7 @@ public final class InjectionTest {
     try {
       graph.validate();
       fail();
-    } catch (IllegalArgumentException expected) {
+    } catch (IllegalStateException expected) {
     }
   }
 
@@ -592,5 +592,32 @@ public final class InjectionTest {
     BoundTwoWays membersInjected = new BoundTwoWays();
     graph.inject(membersInjected);
     assertEquals("Coke", membersInjected.s);
+  }
+
+  static class NoInjections {
+  }
+
+  @Test public void entryPointNeedsNoInjectAnnotation() {
+    @Module(entryPoints = NoInjections.class)
+    class TestModule {
+    }
+
+    ObjectGraph.get(new TestModule()).validate();
+  }
+
+  @Test public void nonEntryPointNeedsInjectAnnotation() {
+    @Module
+    class TestModule {
+      @Provides String provideString(NoInjections noInjections) {
+        throw new AssertionError();
+      }
+    }
+
+    ObjectGraph graph = ObjectGraph.get(new TestModule());
+    try {
+      graph.validate();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
   }
 }

--- a/core/src/test/java/dagger/MembersInjectorTest.java
+++ b/core/src/test/java/dagger/MembersInjectorTest.java
@@ -94,7 +94,7 @@ public final class MembersInjectorTest {
     try {
       graph.getInstance(TestEntryPoint.class);
       fail();
-    } catch (IllegalArgumentException expected) {
+    } catch (IllegalStateException expected) {
     }
   }
 
@@ -111,7 +111,7 @@ public final class MembersInjectorTest {
     try {
       graph.getInstance(TestEntryPoint.class);
       fail();
-    } catch (IllegalArgumentException expected) {
+    } catch (IllegalStateException expected) {
     }
   }
 
@@ -128,7 +128,7 @@ public final class MembersInjectorTest {
     try {
       graph.getInstance(TestEntryPoint.class);
       fail();
-    } catch (IllegalArgumentException expected) {
+    } catch (IllegalStateException expected) {
     }
   }
 
@@ -177,7 +177,7 @@ public final class MembersInjectorTest {
     try {
       graph.getInstance(TestEntryPoint.class);
       fail();
-    } catch (IllegalArgumentException expected) {
+    } catch (IllegalStateException expected) {
     }
   }
 


### PR DESCRIPTION
This is necessary so that generic framework code can inject arbitrary
entry points (like JUnit test cases or Android activities) without
concern for whether the specific entry point has any @Inject annotations.
