### PR TITLE
Clean up the travis config to do a proper deps install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
-
+install: mvn install clean --fail-never --quiet -DskipTests=true -Dinvoker.skip=true
+script: mvn verify
 notifications:
   email: false


### PR DESCRIPTION
Clean up the travis config to do a proper deps install, execute a full phase build cycle (up to verify rather than merely test) and ensure that the invoker plugin (which will come later) doesn't execute during dependency installation.
