### PR TITLE
Add invoker-based integration tests of the build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,12 +5,31 @@ If you would like to contribute code to Dagger you can do so through GitHub by
 forking the repository and sending a pull request.
 
 When submitting code, please make every effort to follow existing conventions
-and style in order to keep the code as readable as possible. Please also make
-sure your code compiles by running `mvn clean verify`. Checkstyle failures
-during compilation indicate errors in your style and can be viewed in the
-`checkstyle-result.xml` file.
+and style in order to keep the code as readable as possible.  
 
-Before your code can be accepted into the project you must also sign the
+Where appropriate, please provide unit tests or integration tests. Unit tests
+should be JUnit based tests and can use either standard JUnit assertions or
+FEST assertions and be added to `<project>/src/test/java`.  Changes to build-time
+behaviour (such as changes to code generation or graph validation) should go into
+small maven projects using the `maven-invoker-plugin`.  Examples of this are in
+`core/src/it` and can include bean-shell verification scripts and other
+facilities provided by `maven-invoker-plugin`.
+
+Please make sure your code compiles by running `mvn clean verify` which will
+execute both unit and integration test phases.  Additionally, consider using 
+http://travis-ci.org to validate your branches before you even put them into
+pull requests.  All pull requests will be validated by Travis-ci in any case
+and must pass before being merged.
+
+If you are adding or modifying files you may add your own copyright line, but
+please ensure that the form is consistent with the existing files, and please
+note that a Square, Inc. copyright line must appear in every copyright notice.
+All files are released with the Apache 2.0 license.
+
+Checkstyle failures during compilation indicate errors in your style and can be
+viewed in the `checkstyle-result.xml` file.
+
+Before your code can be accepted into the project you must sign the
 [Individual Contributor License Agreement (CLA)][1].
 
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -59,6 +59,29 @@
                     <compilerArgument>-proc:none</compilerArgument>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <version>1.7</version>
+                <configuration>
+                    <addTestClassPath>true</addTestClassPath>
+                    <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                    <pomIncludes><pomInclude>*/pom.xml</pomInclude></pomIncludes>
+                    <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+                    <postBuildHookScript>verify</postBuildHookScript>
+		            <filterProperties>
+		              <dagger.version>${project.version}</dagger.version>
+		            </filterProperties>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <goals>
+                            <goal>install</goal>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/core/src/it/missing-at-inject-constructor/invoker.properties
+++ b/core/src/it/missing-at-inject-constructor/invoker.properties
@@ -1,0 +1,1 @@
+invoker.buildResult=failure

--- a/core/src/it/missing-at-inject-constructor/pom.xml
+++ b/core/src/it/missing-at-inject-constructor/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (C) 2012 Square, Inc.
+ Copyright (C) 2012 Google, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.squareup.dagger.tests</groupId>
+  <version>@dagger.version@</version>
+  <packaging>jar</packaging>
+  <artifactId>missing-at-inject-constructor</artifactId>
+  <name>Dagger Integration Test Basic</name>
+  <dependencies>
+    <dependency>
+      <groupId>com.squareup</groupId>
+      <artifactId>dagger</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration><source>1.5</source><target>1.5</target></configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/core/src/it/missing-at-inject-constructor/src/main/java/test/TestApp.java
+++ b/core/src/it/missing-at-inject-constructor/src/main/java/test/TestApp.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2012 Google, Inc.
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.Module;
+
+import dagger.ObjectGraph;
+import javax.inject.Inject;
+
+class TestApp implements Runnable {
+  @Inject Dependency dep;
+
+  @Override public void run() {
+    dep.doit();
+  }
+
+  public static void main(String[] args) {
+    ObjectGraph.get(new TestModule()).getInstance(TestApp.class).run();
+  }
+  
+  static class Dependency {
+    // missing @Inject Dependency() {}
+    public void doit() { throw AssertionError(); };
+  }
+  
+  @Module(entryPoints = TestApp.class)
+  static class TestModule {
+    /* missing */ // @Provides Dependency a() { return new Dependency(); }
+  }
+}

--- a/core/src/it/missing-at-inject-constructor/verify.bsh
+++ b/core/src/it/missing-at-inject-constructor/verify.bsh
@@ -1,0 +1,7 @@
+import dagger.testing.it.BuildLogValidator;
+import java.io.File;
+
+File buildLog = new File(basedir, "build.log");
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "No injectable members on test.TestApp.Dependency.", 
+	"required by test.TestApp for test.TestApp.TestModule"});

--- a/core/src/it/simple-missing-dependency-failure/invoker.properties
+++ b/core/src/it/simple-missing-dependency-failure/invoker.properties
@@ -1,0 +1,1 @@
+invoker.buildResult=failure

--- a/core/src/it/simple-missing-dependency-failure/pom.xml
+++ b/core/src/it/simple-missing-dependency-failure/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (C) 2012 Square, Inc.
+ Copyright (C) 2012 Google, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.squareup.dagger.tests</groupId>
+  <artifactId>missing-dependency</artifactId>
+  <version>@dagger.version@</version>
+  <packaging>jar</packaging>
+  <name>Dagger Integration Test Basic</name>
+  <dependencies>
+    <dependency>
+      <groupId>com.squareup</groupId>
+      <artifactId>dagger</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration><source>1.5</source><target>1.5</target></configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/core/src/it/simple-missing-dependency-failure/src/main/java/test/TestApp.java
+++ b/core/src/it/simple-missing-dependency-failure/src/main/java/test/TestApp.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2012 Google, Inc.
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.Module;
+
+import dagger.ObjectGraph;
+import javax.inject.Inject;
+
+class TestApp implements Runnable {
+  @Inject Dependency dep;
+
+  @Override public void run() {
+    dep.doit();
+  }
+
+  public static void main(String[] args) {
+    ObjectGraph.get(new TestModule()).getInstance(TestApp.class).run();
+  }
+  
+  static interface Dependency {
+    void doit();
+  }
+  
+  @Module(entryPoints = TestApp.class)
+  static class TestModule {
+    /* missing */ // @Provides Dependency a() { return new Dependency(); }
+  }
+}

--- a/core/src/it/simple-missing-dependency-failure/verify.bsh
+++ b/core/src/it/simple-missing-dependency-failure/verify.bsh
@@ -1,0 +1,7 @@
+import dagger.testing.it.BuildLogValidator;
+import java.io.File;
+
+File buildLog = new File(basedir, "build.log");
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "No binding for test.TestApp$Dependency",
+    "required by test.TestApp for test.TestApp.TestModule"});

--- a/core/src/test/java/dagger/testing/it/BuildLogValidator.java
+++ b/core/src/test/java/dagger/testing/it/BuildLogValidator.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2012 Google, Inc.
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dagger.testing.it;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.Charset;
+
+public class BuildLogValidator {
+
+  /**
+   * Processes a log file, ensuring it has all the provided strings within it.
+   *
+   * @param buildLogfile a log file to be searched
+   * @param expectedStrings the strings that must be present in the log file for it to be valid
+   */
+  public void assertHasText(File buildLogfile, String ... expectedStrings) throws Throwable {
+    String buildOutput;
+    FileInputStream stream = new FileInputStream(buildLogfile);
+    try {
+      FileChannel fc = stream.getChannel();
+      MappedByteBuffer buf = fc.map(FileChannel.MapMode.READ_ONLY, 0, fc.size());
+      buildOutput = Charset.defaultCharset().decode(buf).toString();
+    } finally {
+      stream.close();
+    }
+    if (buildOutput == null) {
+      throw new Exception("Could not read build output");
+    }
+
+    StringBuilder sb = new StringBuilder("Build output did not contain expected error text:");
+    boolean missing = false;
+
+    for (String expected : expectedStrings) {
+      if (!buildOutput.contains(expected)) {
+        missing = true;
+        sb.append("\n    \"").append(expected).append("\"");
+      }
+    }
+    if (missing) {
+      sb.append("\n\nBuild Output:\n\n");
+      boolean containsError = false;
+      for(String line : buildOutput.split("\n")) {
+        if (line.contains("[ERROR]")) {
+          containsError = true;
+          sb.append("\n        ").append(line);
+        }
+      }
+      if (!containsError) {
+        sb.append("\nTEST BUILD SUCCEEDED.\n");
+      }
+      throw new Exception(sb.toString());
+    }
+  }
+
+}


### PR DESCRIPTION
Add invoker-based integration tests of the build (particularly including code-generation) to allow for expected failing builds to be tested and verified.
