### PR TITLE
Make dot-writer avoid getDependencies() on UNRESOLVED bindings

### DIFF
--- a/core/src/main/java/dagger/internal/Binding.java
+++ b/core/src/main/java/dagger/internal/Binding.java
@@ -114,4 +114,8 @@ public class Binding<T> implements Provider<T>, MembersInjector<T> {
   public void setCycleFree(boolean cycleFree) {
     this.bits = cycleFree ? (bits | CYCLE_FREE) : (bits & ~CYCLE_FREE);
   }
+
+  @Override public String toString() {
+    return "Binding[provideKey=\"" + provideKey + "\", memberskey=\"" + membersKey + "\"]";
+  }
 }

--- a/core/src/main/java/dagger/internal/GraphVisualizer.java
+++ b/core/src/main/java/dagger/internal/GraphVisualizer.java
@@ -49,11 +49,17 @@ public final class GraphVisualizer {
     for (Map.Entry<Binding<?>, String> entry : namesIndex.entrySet()) {
       Binding<?> sourceBinding = entry.getKey();
       String sourceName = entry.getValue();
-      Set<Binding<?>> dependencies = new HashSet<Binding<?>>();
-      sourceBinding.getDependencies(dependencies, dependencies);
-      for (Binding<?> targetBinding : dependencies) {
-        String targetName = namesIndex.get(targetBinding);
-        writer.edge(sourceName, targetName);
+      try {
+        Set<Binding<?>> dependencies = new HashSet<Binding<?>>();
+        if (sourceBinding != Binding.UNRESOLVED) {
+          sourceBinding.getDependencies(dependencies, dependencies);
+        }
+        for (Binding<?> targetBinding : dependencies) {
+          String targetName = namesIndex.get(targetBinding);
+          writer.edge(sourceName, targetName);
+        }
+      } catch (Exception e) {
+        throw new IllegalStateException("Could not write binding: \"" + sourceBinding + "\"", e);
       }
     }
     writer.endGraph();


### PR DESCRIPTION
Make dot-writer avoid getDependencies() on UNRESOLVED bindings, since not every wiring fed to the dot-writer will be a valid graph spec (for example, failing build integration tests).  Also, add a toString() on binding so it shows up in debugging, and ensure that a failed binding write (to a dot file) has a wrapped exception that is clearer.
