### PR TITLE
Make UNRESOLVED Binding be effectively a null object, and use it polymorphically.

### DIFF
--- a/core/src/main/java/dagger/internal/Binding.java
+++ b/core/src/main/java/dagger/internal/Binding.java
@@ -22,8 +22,14 @@ import javax.inject.Provider;
 /**
  * Injects a value of a specific type.
  */
-public class Binding<T> implements Provider<T>, MembersInjector<T> {
-  public static final Binding<Object> UNRESOLVED = new Binding<Object>(null, null, false, null);
+public abstract class Binding<T> implements Provider<T>, MembersInjector<T> {
+  public static final Binding<Object> UNRESOLVED = new Binding<Object>(null, null, false, null) {
+    @Override public void getDependencies(
+        java.util.Set<dagger.internal.Binding<?>> getBindings,
+        java.util.Set<dagger.internal.Binding<?>> injectMembersBindings) {
+      // do nothing
+    }
+  };
 
   /** Set if the provided instance is always the same object. */
   private static final int SINGLETON = 1 << 0;

--- a/core/src/main/java/dagger/internal/GraphVisualizer.java
+++ b/core/src/main/java/dagger/internal/GraphVisualizer.java
@@ -49,17 +49,11 @@ public final class GraphVisualizer {
     for (Map.Entry<Binding<?>, String> entry : namesIndex.entrySet()) {
       Binding<?> sourceBinding = entry.getKey();
       String sourceName = entry.getValue();
-      try {
-        Set<Binding<?>> dependencies = new HashSet<Binding<?>>();
-        if (sourceBinding != Binding.UNRESOLVED) {
-          sourceBinding.getDependencies(dependencies, dependencies);
-        }
-        for (Binding<?> targetBinding : dependencies) {
-          String targetName = namesIndex.get(targetBinding);
-          writer.edge(sourceName, targetName);
-        }
-      } catch (Exception e) {
-        throw new IllegalStateException("Could not write binding: \"" + sourceBinding + "\"", e);
+      Set<Binding<?>> dependencies = new HashSet<Binding<?>>();
+      sourceBinding.getDependencies(dependencies, dependencies);
+      for (Binding<?> targetBinding : dependencies) {
+        String targetName = namesIndex.get(targetBinding);
+        writer.edge(sourceName, targetName);
       }
     }
     writer.endGraph();


### PR DESCRIPTION
Make UNRESOLVED Binding be effectively a null object, and use it polymorphically.  Also, make the Binding class abstract, to prevent anyone from instantiating it unintentionally and getting run-time unimplemented exceptions. 
