### PR TITLE
Extension graphs. 

### DIFF
--- a/compiler/src/it/extension-graph/pom.xml
+++ b/compiler/src/it/extension-graph/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (C) 2012 Square, Inc.
+ Copyright (C) 2012 Google, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.squareup.dagger.tests</groupId>
+  <artifactId>extension-graph</artifactId>
+  <version>@dagger.version@</version>
+  <packaging>jar</packaging>
+  <name>Dagger Integration Test Basic</name>
+  <dependencies>
+    <dependency>
+      <groupId>com.squareup</groupId>
+      <artifactId>dagger</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration><source>1.5</source><target>1.5</target></configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/extension-graph/src/main/java/test/TestApp.java
+++ b/compiler/src/it/extension-graph/src/main/java/test/TestApp.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2012 Google, Inc.
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.ObjectGraph;
+import dagger.Module;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+class TestApp implements Runnable {
+  @Inject C c;
+
+  @Override public void run() {
+    c.doit();
+  }
+
+  public static void main(String[] args) {
+    ObjectGraph root = ObjectGraph.create(new RootModule());
+    ObjectGraph extension = root.extend(new ExtensionModule());
+    extension.get(TestApp.class).run();
+  }
+  
+  @Module(entryPoints = { A.class, B.class })
+  static class RootModule { }
+
+  @Module(augments=RootModule.class, entryPoints = { C.class, TestApp.class })
+  static class ExtensionModule { }
+
+  @Singleton
+  static class A {
+    @Inject A() {}
+  }
+
+  static class B {
+    @Inject A a;
+    @Inject B() {}
+  }
+
+  static class C {
+    @Inject A a;
+    @Inject B b;
+    @Inject C() {}
+    public void doit() {};
+  }
+}

--- a/core/src/main/java/dagger/Module.java
+++ b/core/src/main/java/dagger/Module.java
@@ -46,10 +46,18 @@ public @interface Module {
   Class<?>[] includes() default { };
 
   /**
+   * An optional, {@code @Module}-annotated class whose abstract object graph
+   * this module extends.  At run-time, this module should be supplied to an
+   * existing graph to extend it with {@link ObjectGraph#extend(Object...)}
+   */
+  Class<?> augments() default Void.class;
+
+  /**
    * True if all of the bindings required by this module can also be satisfied
    * by this module. If a module is complete it is eligible for additional
    * static checking: tools can detect if required bindings are not available.
    * Modules that have external dependencies must use {@code complete = false}.
    */
   boolean complete() default true;
+
 }

--- a/core/src/main/java/dagger/internal/RuntimeAggregatingPlugin.java
+++ b/core/src/main/java/dagger/internal/RuntimeAggregatingPlugin.java
@@ -39,12 +39,12 @@ public class RuntimeAggregatingPlugin implements Plugin {
    * Returns a full set of module adapters, including module adapters for included
    * modules.
    */
-  public ModuleAdapter<?>[] getAllModuleAdapters(Object[] seedModules) {
+  public static Map<Class<?>, ModuleAdapter<?>> getAllModuleAdapters(Plugin plugin, Object[] seedModules) {
     // Create a module adapter for each seed module.
     ModuleAdapter<?>[] seedAdapters = new ModuleAdapter<?>[seedModules.length];
     int s = 0;
     for (Object module : seedModules) {
-      seedAdapters[s++] = getModuleAdapter(module.getClass(), module);
+      seedAdapters[s++] = plugin.getModuleAdapter(module.getClass(), module);
     }
 
     Map<Class<?>, ModuleAdapter<?>> adaptersByModuleType
@@ -59,24 +59,23 @@ public class RuntimeAggregatingPlugin implements Plugin {
     // Next add adapters for the modules that we need to construct. This creates
     // instances of modules as necessary.
     for (ModuleAdapter<?> adapter : seedAdapters) {
-      collectIncludedModulesRecursively(adapter, adaptersByModuleType);
+      collectIncludedModulesRecursively(plugin, adapter, adaptersByModuleType);
     }
 
-    return adaptersByModuleType.values().toArray(
-        new ModuleAdapter<?>[adaptersByModuleType.size()]);
+    return adaptersByModuleType;
   }
 
   /**
    * Fills {@code result} with the module adapters for the includes of {@code
    * adapter}, and their includes recursively.
    */
-  private void collectIncludedModulesRecursively(ModuleAdapter<?> adapter,
+  private static void collectIncludedModulesRecursively(Plugin plugin, ModuleAdapter<?> adapter,
       Map<Class<?>, ModuleAdapter<?>> result) {
     for (Class<?> include : adapter.includes) {
       if (!result.containsKey(include)) {
-        ModuleAdapter<Object> includedModuleAdapter = getModuleAdapter(include, null);
+        ModuleAdapter<Object> includedModuleAdapter = plugin.getModuleAdapter(include, null);
         result.put(include, includedModuleAdapter);
-        collectIncludedModulesRecursively(includedModuleAdapter, result);
+        collectIncludedModulesRecursively(plugin, includedModuleAdapter, result);
       }
     }
   }

--- a/core/src/main/java/dagger/internal/plugins/reflect/ReflectiveModuleAdapter.java
+++ b/core/src/main/java/dagger/internal/plugins/reflect/ReflectiveModuleAdapter.java
@@ -80,10 +80,17 @@ public class ReflectiveModuleAdapter extends ModuleAdapter<Object> {
   }
 
   @Override protected Object newModule() {
+    if (moduleClass.isInterface()) {
+      throw new IllegalStateException(moduleClass.getSimpleName() + " is an interface.");
+    }
     try {
-      Constructor<?> includeConstructor = moduleClass.getDeclaredConstructor();
-      includeConstructor.setAccessible(true);
-      return includeConstructor.newInstance();
+      try {
+        Constructor<?> includeConstructor = moduleClass.getDeclaredConstructor();
+        includeConstructor.setAccessible(true);
+        return includeConstructor.newInstance();
+      } catch (NoSuchMethodException e) {
+        return moduleClass.newInstance();
+      }
     } catch (Exception e) {
       throw new IllegalArgumentException("Unable to instantiate " + moduleClass.getName(), e);
     }

--- a/core/src/test/java/dagger/ExtensionTest.java
+++ b/core/src/test/java/dagger/ExtensionTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2012 Google Inc.
+ * Copyright (C) 2012 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dagger;
+
+import java.util.Arrays;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+public final class ExtensionTest {
+  @Singleton
+  static class A {
+    @Inject A() {}
+  }
+
+  static class B {
+    @Inject A a;
+  }
+
+  @Singleton
+  static class C {
+    @Inject A a;
+    @Inject B b;
+  }
+
+  static class D {
+    @Inject A a;
+    @Inject B b;
+    @Inject C c;
+  }
+
+  @Module(entryPoints = { A.class, B.class }) static class RootModule { }
+
+  @Module(augments = RootModule.class, entryPoints = { C.class, D.class })
+  static class ExtensionModule { }
+
+  @Test public void basicExtension() {
+    assertNotNull(ObjectGraph.create(new RootModule()).extend(new ExtensionModule()));
+  }
+
+  @Test public void basicInjection() {
+    ObjectGraph root = ObjectGraph.create(new RootModule());
+    assertThat(root.get(A.class)).isNotNull();
+    assertThat(root.get(A.class)).isSameAs(root.get(A.class)); // Present and Singleton.
+    assertThat(root.get(B.class)).isNotSameAs(root.get(B.class)); // Not singleton.
+    assertFailNoEntryPoint(root, C.class); // Not declared in RootModule.
+    assertFailNoEntryPoint(root, D.class); // Not declared in RootModule.
+
+    // Extension graph behaves as the root graph would for root-ish things.
+    ObjectGraph extension = root.extend(new ExtensionModule());
+    assertThat(root.get(A.class)).isSameAs(extension.get(A.class));
+    assertThat(root.get(B.class)).isNotSameAs(extension.get(B.class));
+    assertThat(root.get(B.class).a).isSameAs(extension.get(B.class).a);
+
+    assertThat(extension.get(C.class).a).isNotNull();
+    assertThat(extension.get(D.class).c).isNotNull();
+  }
+
+  @Test public void scopedGraphs() {
+    ObjectGraph app = ObjectGraph.create(new RootModule());
+    assertThat(app.get(A.class)).isNotNull();
+    assertThat(app.get(A.class)).isSameAs(app.get(A.class));
+    assertThat(app.get(B.class)).isNotSameAs(app.get(B.class));
+    assertFailNoEntryPoint(app, C.class);
+    assertFailNoEntryPoint(app, D.class);
+
+    ObjectGraph request1 = app.extend(new ExtensionModule());
+    ObjectGraph request2 = app.extend(new ExtensionModule());
+    for (ObjectGraph request : Arrays.asList(request1, request2)) {
+      assertThat(request.get(A.class)).isNotNull();
+      assertThat(request.get(A.class)).isSameAs(request.get(A.class));
+      assertThat(request.get(B.class)).isNotSameAs(request.get(B.class));
+      assertThat(request.get(C.class)).isNotNull();
+      assertThat(request.get(C.class)).isSameAs(request.get(C.class));
+      assertThat(request.get(D.class)).isNotSameAs(request.get(D.class));
+    }
+
+    // Singletons are one-per-graph-instance where they are declared.
+    assertThat(request1.get(C.class)).isNotSameAs(request2.get(C.class));
+    // Singletons that come from common roots should be one-per-common-graph-instance.
+    assertThat(request1.get(C.class).a).isSameAs(request2.get(C.class).a);
+  }
+
+  private void assertFailNoEntryPoint(ObjectGraph graph, Class<?> clazz) {
+    try {
+      assertThat(graph.get(clazz)).isNull();
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage()).contains("No entry point");
+    }
+  }
+}


### PR DESCRIPTION
Allow a graph to be extended such that extension graph instances will delegate up the chain if they can't satisfy dependencies.  This can be used to implement a 'scope' concept by creating a new extension graph with modules for those appropriately scoped objects being created and collected at the start and end of each scope.
