### PR TITLE
Handle modules with no constructor when passed in as a class

### DIFF
--- a/core/src/main/java/dagger/internal/RuntimeAggregatingPlugin.java
+++ b/core/src/main/java/dagger/internal/RuntimeAggregatingPlugin.java
@@ -39,12 +39,17 @@ public class RuntimeAggregatingPlugin implements Plugin {
    * Returns a full set of module adapters, including module adapters for included
    * modules.
    */
-  public static Map<Class<?>, ModuleAdapter<?>> getAllModuleAdapters(Plugin plugin, Object[] seedModules) {
+  public static Map<Class<?>, ModuleAdapter<?>> getAllModuleAdapters(Plugin plugin,
+      Object[] seedModules) {
     // Create a module adapter for each seed module.
     ModuleAdapter<?>[] seedAdapters = new ModuleAdapter<?>[seedModules.length];
     int s = 0;
     for (Object module : seedModules) {
-      seedAdapters[s++] = plugin.getModuleAdapter(module.getClass(), module);
+      if (module instanceof Class) {
+        seedAdapters[s++] = plugin.getModuleAdapter((Class<?>) module, null); // Plugin constructs.
+      } else {
+        seedAdapters[s++] = plugin.getModuleAdapter(module.getClass(), module);
+      }
     }
 
     Map<Class<?>, ModuleAdapter<?>> adaptersByModuleType

--- a/core/src/test/java/dagger/ModuleIncludesTest.java
+++ b/core/src/test/java/dagger/ModuleIncludesTest.java
@@ -154,4 +154,27 @@ public final class ModuleIncludesTest {
     objectGraph.inject(entryPoint);
     assertThat(entryPoint.s).isEqualTo("a");
   }
+
+  static class A {}
+
+  static class B { @Inject A a; }
+
+  @Module(entryPoints = A.class) public static class TestModuleA {
+    @Provides A a() { return new A(); }
+  }
+
+  @Module(includes = TestModuleA.class, entryPoints = B.class) public static class TestModuleB {}
+
+  @Test public void autoInstantiationOfModules() {
+    // Have to make these non-method-scoped or instantiation errors occur.
+    ObjectGraph objectGraph = ObjectGraph.create(TestModuleA.class);
+    assertThat(objectGraph.get(A.class)).isNotNull();
+  }
+
+  @Test public void autoInstantiationOfIncludedModules() {
+    // Have to make these non-method-scoped or instantiation errors occur.
+    ObjectGraph objectGraph = ObjectGraph.create(new TestModuleB()); // TestModuleA auto-created.
+    assertThat(objectGraph.get(A.class)).isNotNull();
+    assertThat(objectGraph.get(B.class).a).isNotNull();
+  }
 }


### PR DESCRIPTION
Handle modules with no constructor when passed in as a class and add a test case to ensure that modules included by modules can be instantiated if they're not passed in as instances.
