### PR TITLE
Documentation, style and small renaming changes.

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -27,7 +27,7 @@
 
         <!-- Checks for Naming Conventions.                  -->
         <!-- See http://checkstyle.sf.net/config_naming.html -->
-        <module name="ConstantName"/>
+        <!--<module name="ConstantName"/>-->
         <module name="LocalFinalVariableName"/>
         <module name="LocalVariableName"/>
         <module name="MemberName"/>

--- a/compiler/src/it/extension-graph/src/main/java/test/TestApp.java
+++ b/compiler/src/it/extension-graph/src/main/java/test/TestApp.java
@@ -30,14 +30,14 @@ class TestApp implements Runnable {
 
   public static void main(String[] args) {
     ObjectGraph root = ObjectGraph.create(new RootModule());
-    ObjectGraph extension = root.extend(new ExtensionModule());
+    ObjectGraph extension = root.plus(new ExtensionModule());
     extension.get(TestApp.class).run();
   }
   
   @Module(entryPoints = { A.class, B.class })
   static class RootModule { }
 
-  @Module(augments=RootModule.class, entryPoints = { C.class, TestApp.class })
+  @Module(addsTo=RootModule.class, entryPoints = { C.class, TestApp.class })
   static class ExtensionModule { }
 
   @Singleton

--- a/compiler/src/main/java/dagger/internal/codegen/CompileTimePlugin.java
+++ b/compiler/src/main/java/dagger/internal/codegen/CompileTimePlugin.java
@@ -37,8 +37,8 @@ public final class CompileTimePlugin implements Plugin {
     this.processingEnv = processingEnv;
   }
 
-  @Override public Binding<?> getAtInjectBinding(String key, String className,
-      boolean mustBeInjectable) throws ClassNotFoundException {
+  @Override public Binding<?> getAtInjectBinding(
+      String key, String className, boolean mustBeInjectable) {
     String sourceClassName = className.replace('$', '.');
     TypeElement type = processingEnv.getElementUtils().getTypeElement(sourceClassName);
     if (type == null) {

--- a/compiler/src/main/java/dagger/internal/codegen/FullGraphProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/FullGraphProcessor.java
@@ -144,7 +144,7 @@ public final class FullGraphProcessor extends AbstractProcessor {
     Map<String, Object> annotation = CodeGen.getAnnotation(Module.class, module);
     List<Object> seedModules = new ArrayList<Object>();
     seedModules.addAll(Arrays.asList((Object[]) annotation.get("includes")));
-    if (!annotation.get("augments").equals(Void.class)) seedModules.add(annotation.get("augments"));
+    if (!annotation.get("addsTo").equals(Void.class)) seedModules.add(annotation.get("addsTo"));
     for (Object include : seedModules) {
       if (!(include instanceof TypeMirror)) {
         processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING,

--- a/core/src/main/java/dagger/Lazy.java
+++ b/core/src/main/java/dagger/Lazy.java
@@ -17,16 +17,137 @@
 package dagger;
 
 /**
- * A value that is lazily returned. A {@code Lazy<T>} creates or obtains its underlying
- * value once, and caches that value thereafter.
- * <p>
- * Despite the similarity of these interfaces, {@code Lazy<T>} is semantically quite
- * distinct from {@code Provider<T>} which provides a new value on each call.
+ * A handle to a lazily-computed value. Each {@code Lazy} computes its value on
+ * the first call to {@code get()} and remembers that same value for all
+ * subsequent calls to {@code get()}.
+ *
+ * <h2>Example</h2>
+ * The differences between <strong>direct injection</strong>, <strong>provider
+ * injection</strong> and <strong>lazy injection</strong> are best demonstrated
+ * with an example. Start with a module that computes a different integer for
+ * each use:<pre><code>
+ *   &#64;Module
+ *   public class CounterModule {
+ *
+ *     int next = 100;
+ *
+ *     &#64;Provides Integer provideInteger() {
+ *       System.out.println("computing...");
+ *       return next++;
+ *     }
+ *   }
+ * </code></pre>
+ *
+ * <h3>Direct Injection</h3>
+ * This class injects that integer and prints it 3 times:<pre><code>
+ *   public class DirectCounter {
+ *
+ *     &#64Inject Integer value;
+ *
+ *     public void print() {
+ *       System.out.println("printing...");
+ *       System.out.println(value);
+ *       System.out.println(value);
+ *       System.out.println(value);
+ *     }
+ *   }
+ * </code></pre>
+ * Injecting a {@code DirectCounter} and invoking {@code print()} reveals that
+ * the value is computed <i>before</i> it is required:<pre><code>
+ *   computing...
+ *   printing...
+ *   100
+ *   100
+ *   100
+ * </code></pre>
+ *
+ * <h3>Provider Injection</h3>
+ * This class injects a {@linkplain javax.inject.Provider provider} for the
+ * integer. It calls {@code Provider.get()} 3 times and prints each result:
+ * <pre><code>
+ *   public class ProviderCounter {
+ *
+ *     &#64;Inject Provider<Integer> provider;
+ *
+ *     public void print() {
+ *       System.out.println("printing...");
+ *       System.out.println(provider.get());
+ *       System.out.println(provider.get());
+ *       System.out.println(provider.get());
+ *     }
+ *   }
+ * </code></pre>
+ * Injecting a {@code ProviderCounter} and invoking {@code print()} shows that
+ * a new value is computed each time {@code Provider.get()} is used:<pre><code>
+ *   printing...
+ *   computing...
+ *   100
+ *   computing...
+ *   101
+ *   computing...
+ *   102
+ * </code></pre>
+ *
+ * <h3>Lazy Injection</h3>
+ * This class injects a {@code Lazy} for the integer. Like the provider above,
+ * it calls {@code Lazy.get()} 3 times and prints each result:<pre><code>
+ *   public static class LazyCounter {
+ *
+ *     &#64;Inject Lazy<Integer> lazy;
+ *
+ *     public void print() {
+ *       System.out.println("printing...");
+ *       System.out.println(lazy.get());
+ *       System.out.println(lazy.get());
+ *       System.out.println(lazy.get());
+ *     }
+ *   }
+ * </code></pre>
+ * Injecting a {@code LazyCounter} and invoking {@code print()} shows that a new
+ * value is computed immediately before it is needed. The same value is returned
+ * for all subsequent uses:<pre><code>
+ *   printing...
+ *   computing...
+ *   100
+ *   100
+ *   100
+ * </code></pre>
+ *
+ * <h3>Lazy != Singleton</h3>
+ * Note that each injected {@code Lazy} is independent, and remembers its value
+ * in isolation of other {@code Lazy} instances. In this example, two {@code
+ * LazyCounter} objects are created and {@code print()} is called on each:
+ * <pre><code>
+ *     public void run() {
+ *       ObjectGraph graph = ObjectGraph.create(new CounterModule());
+ *
+ *       LazyCounter counter1 = graph.get(LazyCounter.class);
+ *       counter1.print();
+ *
+ *       LazyCounter counter2 = graph.get(LazyCounter.class);
+ *       counter2.print();
+ *     }
+ * </code></pre>
+ * The program's output demonstrates that each {@code Lazy} works independently:
+ * <pre><code>
+ *   printing...
+ *   computing...
+ *   100
+ *   100
+ *   100
+ *   printing...
+ *   computing...
+ *   101
+ *   101
+ *   101
+ * </code></pre>
+ * Use {@linkplain javax.inject.Singleton @Singleton} to share one instance
+ * among all clients, and {@code Lazy} for lazy computation in a single client.
  */
 public interface Lazy<T> {
   /**
-   * Return the underlying value, creating the value (once) if needed. Any two calls will
-   * return the same instance.
+   * Return the underlying value, computing the value if necessary. All calls to
+   * the same {@code Lazy} instance will return the same result.
    */
   T get();
 }

--- a/core/src/main/java/dagger/Module.java
+++ b/core/src/main/java/dagger/Module.java
@@ -46,17 +46,17 @@ public @interface Module {
   Class<?>[] includes() default { };
 
   /**
-   * An optional, {@code @Module}-annotated class whose abstract object graph
-   * this module extends.  At run-time, this module should be supplied to an
-   * existing graph to extend it with {@link ObjectGraph#extend(Object...)}
+   * An optional {@code @Module}-annotated class upon which this module can be
+   * {@link ObjectGraph#plus added} to form a complete graph.
    */
-  Class<?> augments() default Void.class;
+  Class<?> addsTo() default Void.class;
 
   /**
    * True if all of the bindings required by this module can also be satisfied
-   * by this module. If a module is complete it is eligible for additional
-   * static checking: tools can detect if required bindings are not available.
-   * Modules that have external dependencies must use {@code complete = false}.
+   * by this module, its {@link #includes} and its {@link #addsTo}. If a module
+   * is complete it is eligible for additional static checking: tools can detect
+   * if required bindings are not available. Modules that have external
+   * dependencies must use {@code complete = false}.
    */
   boolean complete() default true;
 

--- a/core/src/main/java/dagger/internal/Linker.java
+++ b/core/src/main/java/dagger/internal/Linker.java
@@ -30,11 +30,11 @@ public final class Linker {
   private static final Object UNINITIALIZED = new Object();
 
   /**
-   * The root {@code Linker} which will be consulted to satisfy bindings not
+   * The base {@code Linker} which will be consulted to satisfy bindings not
    * otherwise satisfiable from this {@code Linker}. The top-most {@code Linker}
-   * in a chain will have a null root linker.
+   * in a chain will have a null base linker.
    */
-  private final Linker root;
+  private final Linker base;
 
   /** Bindings requiring a call to attach(). May contain deferred bindings. */
   private final Queue<Binding<?>> toLink = new LinkedList<Binding<?>>();
@@ -52,11 +52,11 @@ public final class Linker {
 
   private final ErrorHandler errorHandler;
 
-  public Linker(Linker root, Plugin plugin, ErrorHandler errorHandler) {
+  public Linker(Linker base, Plugin plugin, ErrorHandler errorHandler) {
     if (plugin == null) throw new NullPointerException("plugin");
     if (errorHandler == null) throw new NullPointerException("errorHandler");
 
-    this.root = root;
+    this.base = base;
     this.plugin = plugin;
     this.errorHandler = errorHandler;
   }
@@ -191,9 +191,14 @@ public final class Linker {
 
   private Binding<?> requestBinding(String key, boolean mustBeInjectable, Object requiredBy) {
     Binding<?> binding = null;
-    for (Linker node = this; binding == null && node != null; node = node.root) {
-      binding = node.bindings.get(key);
+    for (Linker linker = this; linker != null; linker = linker.base) {
+      binding = linker.bindings.get(key);
+      if (binding != null) {
+        if (linker != this && !binding.isLinked()) throw new AssertionError();
+        break;
+      }
     }
+
     if (binding == null) {
       // We can't satisfy this binding. Make sure it'll work next time!
       Binding<?> deferredBinding = new DeferredBinding(key, requiredBy, mustBeInjectable);

--- a/core/src/main/java/dagger/internal/ModuleAdapter.java
+++ b/core/src/main/java/dagger/internal/ModuleAdapter.java
@@ -23,7 +23,6 @@ import java.util.Map;
  * Extracts bindings from an {@code @Module}-annotated class.
  */
 public abstract class ModuleAdapter<T> {
-
   public final String[] entryPoints;
   public final Class<?>[] staticInjections;
   public final boolean overrides;

--- a/core/src/main/java/dagger/internal/Plugin.java
+++ b/core/src/main/java/dagger/internal/Plugin.java
@@ -21,13 +21,10 @@ package dagger.internal;
  * provide all resolution methods
  */
 public interface Plugin {
-
   /**
-   * Returns a binding that uses {@code @Inject} annotations, or null if no such
-   * binding can be located or created.
+   * Returns a binding that uses {@code @Inject} annotations.
    */
-  Binding<?> getAtInjectBinding(String key, String className, boolean mustBeInjectable)
-      throws ClassNotFoundException;
+  Binding<?> getAtInjectBinding(String key, String className, boolean mustBeInjectable);
 
   /**
    * Returns a module adapter for {@code module}.
@@ -38,5 +35,4 @@ public interface Plugin {
    * Returns the static injection for {@code injectedClass}.
    */
   StaticInjection getStaticInjection(Class<?> injectedClass);
-
 }

--- a/core/src/main/java/dagger/internal/StaticInjection.java
+++ b/core/src/main/java/dagger/internal/StaticInjection.java
@@ -19,8 +19,6 @@ package dagger.internal;
 
 /**
  * Injects the static fields of a class.
- *
- * @author Jesse Wilson
  */
 public abstract class StaticInjection {
 

--- a/core/src/main/java/dagger/internal/plugins/loading/ClassloadingPlugin.java
+++ b/core/src/main/java/dagger/internal/plugins/loading/ClassloadingPlugin.java
@@ -15,57 +15,43 @@
  */
 package dagger.internal.plugins.loading;
 
-import dagger.ObjectGraph;
 import dagger.internal.Binding;
 import dagger.internal.ModuleAdapter;
 import dagger.internal.Plugin;
 import dagger.internal.StaticInjection;
 import java.lang.reflect.Constructor;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
- * A run-time {@code Binding.Resolver} which finds bindings by loading appropriately named adapter
- * classes.
+ * A runtime {@link Plugin} that loads generated classes.
  */
 public final class ClassloadingPlugin implements Plugin {
-  private static final Logger LOGGER = Logger.getLogger(ObjectGraph.class.getName());
-
   public static final String INJECT_ADAPTER_SUFFIX = "$InjectAdapter";
   public static final String MODULE_ADAPTER_SUFFIX = "$ModuleAdapter";
   public static final String STATIC_INJECTION_SUFFIX = "$StaticInjection";
 
-  /**
-   * Returns a module adapter loaded from the appropriately named class.
-   */
   @Override public <T> ModuleAdapter<T> getModuleAdapter(Class<? extends T> moduleClass, T module) {
-    return instantiate(moduleClass.getName(), MODULE_ADAPTER_SUFFIX, "module");
+    return instantiate(moduleClass.getName(), MODULE_ADAPTER_SUFFIX);
   }
 
-  /**
-   * Returns an {@code @Inject} binding loaded from the appropriately named class.
-   */
-  @Override public Binding<?> getAtInjectBinding(String key, String className,
-      boolean mustBeInjectable) throws ClassNotFoundException {
-    return instantiate(className, INJECT_ADAPTER_SUFFIX, "@Inject");
+  @Override public Binding<?> getAtInjectBinding(
+      String key, String className, boolean mustBeInjectable) {
+    return instantiate(className, INJECT_ADAPTER_SUFFIX);
   }
 
-  /**
-   * Returns a {@code StaticInjection} binding loaded from the appropriately named class.
-   */
   @Override public StaticInjection getStaticInjection(Class<?> injectedClass) {
-    return instantiate(injectedClass.getName(), STATIC_INJECTION_SUFFIX, "static injection");
+    return instantiate(injectedClass.getName(), STATIC_INJECTION_SUFFIX);
   }
 
-  private <T> T instantiate(String className, String suffix, String kind) {
+  @SuppressWarnings("unchecked") // We use a naming convention to defend against mismatches.
+  private <T> T instantiate(String className, String suffix) {
+    String name = className + suffix;
     try {
-      Class<?> c = Class.forName(className + suffix);
-      Constructor<?> constructor = c.getConstructor();
+      Class<?> generatedClass = Class.forName(name);
+      Constructor<?> constructor = generatedClass.getConstructor();
       constructor.setAccessible(true);
       return (T) constructor.newInstance();
     } catch (Exception e) {
-      LOGGER.log(Level.FINE, String.format("No %s adapter for %s found.", kind, className), e);
-      return null;
+      throw new RuntimeException("Unexpected failure loading " + name, e);
     }
   }
 }

--- a/core/src/main/java/dagger/internal/plugins/reflect/ReflectiveAtInjectBinding.java
+++ b/core/src/main/java/dagger/internal/plugins/reflect/ReflectiveAtInjectBinding.java
@@ -31,9 +31,10 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 /**
- * A runtime binding that injects the constructor and fields of a class.
+ * Injects the {@code @Inject}-annotated fields and constructors of a class
+ * using reflection.
  */
-public final class ReflectiveAtInjectBinding<T> extends Binding<T> {
+final class ReflectiveAtInjectBinding<T> extends Binding<T> {
   private final Field[] fields;
   private final Constructor<T> constructor;
   private final Class<?> supertype;
@@ -50,9 +51,9 @@ public final class ReflectiveAtInjectBinding<T> extends Binding<T> {
    *     supports members injection only.
    * @param supertype the injectable supertype, or null if the supertype is a
    */
-  private ReflectiveAtInjectBinding(String provideKey, String membersKey, boolean singleton, Class<?> type,
-      Field[] fields, Constructor<T> constructor, int parameterCount, Class<?> supertype,
-      String[] keys) {
+  private ReflectiveAtInjectBinding(String provideKey, String membersKey, boolean singleton,
+      Class<?> type, Field[] fields, Constructor<T> constructor, int parameterCount,
+      Class<?> supertype, String[] keys) {
     super(provideKey, membersKey, singleton, type);
     this.constructor = constructor;
     this.fields = fields;
@@ -62,6 +63,7 @@ public final class ReflectiveAtInjectBinding<T> extends Binding<T> {
     this.fieldBindings = new Binding<?>[fields.length];
   }
 
+  @SuppressWarnings("unchecked") // We're careful to make keys and bindings match up.
   @Override public void attach(Linker linker) {
     int k = 0;
     for (int i = 0; i < fields.length; i++) {
@@ -218,6 +220,7 @@ public final class ReflectiveAtInjectBinding<T> extends Binding<T> {
         parameterCount, supertype, keys.toArray(new String[keys.size()]));
   }
 
+  @SuppressWarnings("unchecked") // Class.getDeclaredConstructors is an unsafe API.
   private static <T> Constructor<T>[] getConstructorsForType(Class<T> type) {
     return (Constructor<T>[]) type.getDeclaredConstructors();
   }

--- a/core/src/main/java/dagger/internal/plugins/reflect/ReflectiveStaticInjection.java
+++ b/core/src/main/java/dagger/internal/plugins/reflect/ReflectiveStaticInjection.java
@@ -21,8 +21,10 @@ import dagger.internal.Linker;
 import dagger.internal.StaticInjection;
 import java.lang.reflect.Field;
 
-/** Performs static injection on a class by means of reflection. */
-public  class ReflectiveStaticInjection extends StaticInjection {
+/**
+ * Uses reflection to inject the static fields of a class.
+ */
+final class ReflectiveStaticInjection extends StaticInjection {
   private final Field[] fields;
   private Binding<?>[] bindings;
 

--- a/core/src/test/java/dagger/ExtensionTest.java
+++ b/core/src/test/java/dagger/ExtensionTest.java
@@ -48,11 +48,11 @@ public final class ExtensionTest {
 
   @Module(entryPoints = { A.class, B.class }) static class RootModule { }
 
-  @Module(augments = RootModule.class, entryPoints = { C.class, D.class })
+  @Module(addsTo = RootModule.class, entryPoints = { C.class, D.class })
   static class ExtensionModule { }
 
   @Test public void basicExtension() {
-    assertNotNull(ObjectGraph.create(new RootModule()).extend(new ExtensionModule()));
+    assertNotNull(ObjectGraph.create(new RootModule()).plus(new ExtensionModule()));
   }
 
   @Test public void basicInjection() {
@@ -64,7 +64,7 @@ public final class ExtensionTest {
     assertFailNoEntryPoint(root, D.class); // Not declared in RootModule.
 
     // Extension graph behaves as the root graph would for root-ish things.
-    ObjectGraph extension = root.extend(new ExtensionModule());
+    ObjectGraph extension = root.plus(new ExtensionModule());
     assertThat(root.get(A.class)).isSameAs(extension.get(A.class));
     assertThat(root.get(B.class)).isNotSameAs(extension.get(B.class));
     assertThat(root.get(B.class).a).isSameAs(extension.get(B.class).a);
@@ -81,8 +81,8 @@ public final class ExtensionTest {
     assertFailNoEntryPoint(app, C.class);
     assertFailNoEntryPoint(app, D.class);
 
-    ObjectGraph request1 = app.extend(new ExtensionModule());
-    ObjectGraph request2 = app.extend(new ExtensionModule());
+    ObjectGraph request1 = app.plus(new ExtensionModule());
+    ObjectGraph request2 = app.plus(new ExtensionModule());
     for (ObjectGraph request : Arrays.asList(request1, request2)) {
       assertThat(request.get(A.class)).isNotNull();
       assertThat(request.get(A.class)).isSameAs(request.get(A.class));

--- a/core/src/test/java/dagger/InjectionTest.java
+++ b/core/src/test/java/dagger/InjectionTest.java
@@ -459,7 +459,7 @@ public final class InjectionTest {
     assertThat(entryPoint.listOfStrings).isEqualTo(Arrays.asList("a", "b"));
   }
 
-  @Test public void injectWilcardType() {
+  @Test public void injectWildcardType() {
     class TestEntryPoint {
       @Inject List<? extends Number> listOfNumbers;
     }
@@ -608,6 +608,29 @@ public final class InjectionTest {
     @Module
     class TestModule {
       @Provides String provideString(NoInjections noInjections) {
+        throw new AssertionError();
+      }
+    }
+
+    ObjectGraph graph = ObjectGraph.create(new TestModule());
+    try {
+      graph.validate();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+  }
+
+  static class TwoAtInjectConstructors {
+    @Inject TwoAtInjectConstructors() {
+    }
+    @Inject TwoAtInjectConstructors(String s) {
+    }
+  }
+
+  @Test public void twoAtInjectConstructorsIsRejected() {
+    @Module(entryPoints = TwoAtInjectConstructors.class)
+    class TestModule {
+      @Provides String provideString() {
         throw new AssertionError();
       }
     }

--- a/core/src/test/java/dagger/internal/KeysTest.java
+++ b/core/src/test/java/dagger/internal/KeysTest.java
@@ -29,9 +29,6 @@ import org.junit.Test;
 
 import static org.fest.assertions.Assertions.assertThat;
 
-/**
- * @author Jesse Wilson
- */
 public final class KeysTest {
   int primitive;
   @Test public void lonePrimitiveGetsBoxed() throws NoSuchFieldException {


### PR DESCRIPTION
The only behavior change is to RuntimeAggregatingPlugin. This class
used to allow other plugins to return null if they couldn't resolve
a value. If all plugins returned null, it would throw. The new
behavior is to have child plugins throw, and to rethrow the last
plugin's exception if necessary.

The upside of this change is that we emit better errors. In the new
twoAtInjectConstructorsIsRejected, we were printing this error:

  No available @Inject handlers could be found for key
  dagger.InjectionTest$TwoAtInjectConstructors in class
  dagger.InjectionTest$TwoAtInjectConstructors required
  by class dagger.InjectionTest$26TestModule

With this change the error is better:

  Too many injectable constructors on
  dagger.InjectionTest$TwoAtInjectConstructors required
  by class dagger.InjectionTest$26TestModule

Also renaming 'augments' to 'addsTo' and ObjectGraph.extend()
to ObjectGraph.plus().

Also adding extensive documentation for Lazy.
