### PR TITLE
Add goal prefix to Maven plugin for short invocation.

### DIFF
--- a/androidmanifest/pom.xml
+++ b/androidmanifest/pom.xml
@@ -62,4 +62,16 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <configuration>
+          <goalPrefix>dagger</goalPrefix>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -140,5 +140,15 @@
         </executions>
       </plugin>
     </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-plugin-plugin</artifactId>
+          <version>2.8</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 </project>


### PR DESCRIPTION
With this you can now run `mvn dagger:generate` from the command line rather than specifying
the entire groupId + artifactId.
