### PR TITLE
Be more careful about mustBeInjectable.

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/FullGraphProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/FullGraphProcessor.java
@@ -97,7 +97,7 @@ public final class FullGraphProcessor extends AbstractProcessor {
         // Gather the entry points from the annotation.
         for (Object entryPoint : (Object[]) annotation.get("entryPoints")) {
           linker.requestBinding(GeneratorKeys.rawMembersKey((TypeMirror) entryPoint),
-              module.getQualifiedName().toString());
+              module.getQualifiedName().toString(), false);
         }
 
         // Gather the static injections.

--- a/core/src/main/java/dagger/ObjectGraph.java
+++ b/core/src/main/java/dagger/ObjectGraph.java
@@ -164,7 +164,7 @@ public final class ObjectGraph {
 
   private void linkEntryPoints() {
     for (Map.Entry<String, Class<?>> entry : entryPoints.entrySet()) {
-      linker.requestEntryPoint(entry.getKey(), entry.getValue());
+      linker.requestBinding(entry.getKey(), entry.getValue(), false);
     }
   }
 
@@ -257,10 +257,10 @@ public final class ObjectGraph {
     }
 
     synchronized (linker) {
-      Binding<?> binding = linker.requestBinding(key, moduleClass);
+      Binding<?> binding = linker.requestBinding(key, moduleClass, false);
       if (binding == null || !binding.isLinked()) {
         linker.linkRequested();
-        binding = linker.requestBinding(key, moduleClass);
+        binding = linker.requestBinding(key, moduleClass, false);
       }
       return binding;
     }

--- a/core/src/main/java/dagger/internal/Linker.java
+++ b/core/src/main/java/dagger/internal/Linker.java
@@ -187,20 +187,20 @@ public final class Linker {
    * enqueued to be linked.
    */
   public Binding<?> requestBinding(String key, Object requiredBy) {
-    return requestBinding(key, true, requiredBy);
+    return requestBinding(key, requiredBy, true);
   }
 
   /**
-   * Like {@link #requestBinding}, but this doesn't require the referenced key
-   * to be injectable. This is necessary so that generic framework code can
-   * inject arbitrary entry points (like JUnit test cases or Android activities)
-   * without concern for whether the specific entry point is injectable.
+   * Returns the binding if it exists immediately. Otherwise this returns
+   * null. If the returned binding didn't exist or was unlinked, it will be
+   * enqueued to be linked.
+   *
+   * @param mustBeInjectable true if the the referenced key doesn't need to be
+   *     injectable. This is necessary for entry points (so that framework code
+   *     can inject arbitrary entry points like JUnit test cases or Android
+   *     activities) and for supertypes.
    */
-  public Binding<?> requestEntryPoint(String key, Class<?> requiredByModule) {
-    return requestBinding(key, false, requiredByModule);
-  }
-
-  private Binding<?> requestBinding(String key, boolean mustBeInjectable, Object requiredBy) {
+  public Binding<?> requestBinding(String key, Object requiredBy, boolean mustBeInjectable) {
     assertLockHeld();
 
     Binding<?> binding = null;

--- a/core/src/main/java/dagger/internal/plugins/reflect/ReflectiveAtInjectBinding.java
+++ b/core/src/main/java/dagger/internal/plugins/reflect/ReflectiveAtInjectBinding.java
@@ -81,7 +81,7 @@ final class ReflectiveAtInjectBinding<T> extends Binding<T> {
       }
     }
     if (supertype != null && supertypeBinding == null) {
-      supertypeBinding = (Binding<? super T>) linker.requestBinding(keys[k], membersKey);
+      supertypeBinding = (Binding<? super T>) linker.requestBinding(keys[k], membersKey, false);
     }
   }
 

--- a/core/src/test/java/dagger/InjectionTest.java
+++ b/core/src/test/java/dagger/InjectionTest.java
@@ -250,7 +250,7 @@ public final class InjectionTest {
     }
   }
 
-  @Test public void subclasses() {
+  @Test public void injectableSupertypes() {
     class TestEntryPoint {
       @Inject Q q;
     }
@@ -267,12 +267,33 @@ public final class InjectionTest {
     assertThat(entryPoint.q.f).isNotNull();
   }
 
+  @Test public void uninjectableSupertypes() {
+    class TestEntryPoint {
+      @Inject T t;
+    }
+
+    @Module(entryPoints = TestEntryPoint.class)
+    class TestModule {
+    }
+
+    TestEntryPoint entryPoint = new TestEntryPoint();
+    ObjectGraph.create(new TestModule()).inject(entryPoint);
+    assertThat(entryPoint.t).isNotNull();
+  }
+
   public static class P {
     @Inject F f;
   }
 
   public static class Q extends P {
     @Inject Q() {}
+  }
+
+  static class S {
+  }
+
+  public static class T extends S {
+    @Inject T() {}
   }
 
   @Test public void singletonsAreNotEager() {
@@ -310,8 +331,6 @@ public final class InjectionTest {
       injected = true;
     }
   }
-
-  static class S {}
 
   @Test public void providerMethodsConflict() {
     @Module


### PR DESCRIPTION
We introduced a bug where non-injectable superclasses prevented
their subclasses from being injected.
