### PR TITLE
Don't require entry points to have injectable constructors.

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/ProvidesProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/ProvidesProcessor.java
@@ -22,7 +22,15 @@ import dagger.internal.Binding;
 import dagger.internal.Linker;
 import dagger.internal.ModuleAdapter;
 import dagger.internal.SetBinding;
-
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
@@ -38,15 +46,6 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
 import javax.tools.JavaFileObject;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static dagger.internal.plugins.loading.ClassloadingPlugin.MODULE_ADAPTER_SUFFIX;
 import static java.lang.reflect.Modifier.FINAL;
@@ -167,7 +166,7 @@ public final class ProvidesProcessor extends AbstractProcessor {
     StringBuilder entryPointsField = new StringBuilder().append("{ ");
     for (Object entryPoint : entryPoints) {
       TypeMirror typeMirror = (TypeMirror) entryPoint;
-      String key = GeneratorKeys.get(typeMirror);
+      String key = GeneratorKeys.rawMembersKey(typeMirror);
       entryPointsField.append(JavaWriter.stringLiteral(key)).append(", ");
     }
     entryPointsField.append("}");

--- a/core/src/main/java/dagger/ObjectGraph.java
+++ b/core/src/main/java/dagger/ObjectGraph.java
@@ -219,8 +219,9 @@ public final class ObjectGraph {
    */
   public <T> T get(Class<T> type) {
     String key = Keys.get(type);
+    String entryPointKey = Keys.getMembersKey(type);
     @SuppressWarnings("unchecked") // The linker matches keys to bindings by their type.
-    Binding<T> binding = (Binding<T>) getEntryPointBinding(key, key);
+    Binding<T> binding = (Binding<T>) getEntryPointBinding(entryPointKey, key);
     return binding.get();
   }
 
@@ -232,16 +233,16 @@ public final class ObjectGraph {
    *     not one of this object graph's entry point types.
    */
   public void inject(Object instance) {
-    String entryPointKey = Keys.get(instance.getClass());
     String membersKey = Keys.getMembersKey(instance.getClass());
     @SuppressWarnings("unchecked") // The linker matches keys to bindings by their type.
-    Binding<Object> binding = (Binding<Object>) getEntryPointBinding(entryPointKey, membersKey);
+    Binding<Object> binding = (Binding<Object>) getEntryPointBinding(membersKey, membersKey);
     binding.injectMembers(instance);
   }
 
   /**
    * @param entryPointKey the key used to store the entry point. This is always
-   *     a regular (provider) key.
+   *     a members injection key because those keys can always be created, even
+   *     if the type has no injectable constructor.
    * @param key the key to use when retrieving the binding. This may be a
    *     regular (provider) key or a members key.
    */

--- a/core/src/main/java/dagger/internal/plugins/reflect/ReflectiveModuleAdapter.java
+++ b/core/src/main/java/dagger/internal/plugins/reflect/ReflectiveModuleAdapter.java
@@ -37,7 +37,7 @@ final class ReflectiveModuleAdapter extends ModuleAdapter<Object> {
 
   public ReflectiveModuleAdapter(Class<?> moduleClass, Module annotation) {
     super(
-        toKeys(annotation.entryPoints()),
+        toMemberKeys(annotation.entryPoints()),
         annotation.staticInjections(),
         annotation.overrides(),
         annotation.includes(),
@@ -45,10 +45,10 @@ final class ReflectiveModuleAdapter extends ModuleAdapter<Object> {
     this.moduleClass = moduleClass;
   }
 
-  private static String[] toKeys(Class<?>[] entryPoints) {
+  private static String[] toMemberKeys(Class<?>[] entryPoints) {
     String[] result = new String[entryPoints.length];
     for (int i = 0; i < entryPoints.length; i++) {
-      result[i] = Keys.get(entryPoints[i]);
+      result[i] = Keys.getMembersKey(entryPoints[i]);
     }
     return result;
   }

--- a/core/src/test/java/dagger/InjectionTest.java
+++ b/core/src/test/java/dagger/InjectionTest.java
@@ -613,6 +613,8 @@ public final class InjectionTest {
   }
 
   static class NoInjections {
+    NoInjections(Void noDefaultConstructorEither) {
+    }
   }
 
   @Test public void entryPointNeedsNoInjectAnnotation() {


### PR DESCRIPTION
We were accidentally requiring this by using the regular
(provider) key for entry points rather than the more lenient
and more available members injector key.
