### PR TITLE
Never say 'null required by' in an error message.

### DIFF
--- a/core/src/main/java/dagger/internal/Linker.java
+++ b/core/src/main/java/dagger/internal/Linker.java
@@ -115,8 +115,14 @@ public final class Linker {
           toLink.add(jitBinding);
           putBinding(jitBinding);
         } catch (Exception e) {
-          addError(e.getMessage() + " required by " + binding.requiredBy);
-          bindings.put(key, Binding.UNRESOLVED);
+          if (e.getMessage() != null) {
+            addError(e.getMessage() + " required by " + binding.requiredBy);
+            bindings.put(key, Binding.UNRESOLVED);
+          } else if (e instanceof RuntimeException) {
+            throw (RuntimeException) e;
+          } else {
+            throw new RuntimeException(e);
+          }
         }
       } else {
         // Attempt to attach the binding to its dependencies. If any dependency

--- a/core/src/main/java/dagger/internal/plugins/reflect/ReflectivePlugin.java
+++ b/core/src/main/java/dagger/internal/plugins/reflect/ReflectivePlugin.java
@@ -38,6 +38,11 @@ public final class ReflectivePlugin implements Plugin {
     } catch (ClassNotFoundException e) {
       throw new RuntimeException(e);
     }
+
+    if (c.isInterface()) {
+      return null;
+    }
+
     return ReflectiveAtInjectBinding.create(c, mustBeInjectable);
   }
 


### PR DESCRIPTION
This fixes two bugs:
- don't try to create an @Inject binding for interfaces
- if we crash, throw the full stacktrace to the user
