### PR TITLE
Making dagger compiler play nice with other codegen processors (#108)

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/FullGraphProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/FullGraphProcessor.java
@@ -52,7 +52,8 @@ import javax.tools.StandardLocation;
 @SupportedAnnotationTypes("dagger.Module")
 @SupportedSourceVersion(SourceVersion.RELEASE_6)
 public final class FullGraphProcessor extends AbstractProcessor {
-  private static Set<Element> delayedModules = new HashSet<Element>();
+  private static final Set<Element> delayedModules = new HashSet<Element>();
+
   /**
    * Perform full-graph analysis on complete modules. This checks that all of
    * the module's dependencies are satisfied.
@@ -67,7 +68,7 @@ public final class FullGraphProcessor extends AbstractProcessor {
       log("Executing full graph processing");
 
       Set<Element> modules = new HashSet<Element>();
-      for (Element e:delayedModules) {
+      for (Element e : delayedModules) {
         modules.add(processingEnv.getTypeUtils().asElement(
             processingEnv.getElementUtils()
                 .getTypeElement(e.asType().toString()).asType()));

--- a/compiler/src/main/java/dagger/internal/codegen/InjectProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/InjectProcessor.java
@@ -56,21 +56,21 @@ import static java.lang.reflect.Modifier.PUBLIC;
 @SupportedAnnotationTypes("javax.inject.Inject")
 @SupportedSourceVersion(SourceVersion.RELEASE_6)
 public final class InjectProcessor extends AbstractProcessor {
-  private static Set<String> delayedInjectedClassNames = new HashSet<String>();
+  private static final Set<String> delayedInjectedClassNames = new HashSet<String>();
 
   @Override public boolean process(Set<? extends TypeElement> types, RoundEnvironment env) {
     try {
       final Set<InjectedClass> injectedClasses = new HashSet<InjectedClass>();
       injectedClasses.addAll(getInjectedClasses(env));
       for (final String e : delayedInjectedClassNames) {
-        // refetching delayed elements by name as previous element object could
-        // not resolve now-available types
+        // Refetching delayed elements by name as previous element object could not resolve
+        // now-available types.
         injectedClasses.add(getInjectedClass(processingEnv.getElementUtils().getTypeElement(e)));
       }
 
       for (InjectedClass injectedClass : injectedClasses) {
         final String injectedClassName = injectedClass.type.toString();
-        // verify that we have access to all types to be injected on this pass
+        // Verify that we have access to all types to be injected on this pass.
         final boolean missingDependentClasses =
             !allTypesExist(injectedClass.fields)
             || (injectedClass.constructor != null && !allTypesExist(injectedClass.constructor
@@ -81,8 +81,8 @@ public final class InjectProcessor extends AbstractProcessor {
           log("injectons delayed in this pass for %s", injectedClass.type);
         } else {
           writeInjectionsForClass(injectedClass);
-          // in case this class has been delayed in an earlier pass, remove it
-          // so we don't re-process it.
+          // In case this class has been delayed in an earlier pass, remove it so we don't
+          // re-process it.
           delayedInjectedClassNames.remove(injectedClassName);
           log("injectons complete for %s", injectedClass.type);
         }
@@ -107,7 +107,7 @@ public final class InjectProcessor extends AbstractProcessor {
 
   /**
    * Check that all element types are currently available in this code
-   * generation pass. Unavailable types will be of kind {@link TypeKind#ERROR}
+   * generation pass. Unavailable types will be of kind {@link TypeKind#ERROR}.
    * @param elements
    *          the elements to check
    * @return true, if all types are available

--- a/compiler/src/main/java/dagger/internal/codegen/ProvidesProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/ProvidesProcessor.java
@@ -71,17 +71,16 @@ public final class ProvidesProcessor extends AbstractProcessor {
 
     try {
       Map<TypeElement, List<ExecutableElement>> providerMethods = providerMethodsByClass(env);
-      for (Map.Entry<String, List<ExecutableElement>> module:delayedTypes.entrySet()) {
+      for (Map.Entry<String, List<ExecutableElement>> module : delayedTypes.entrySet()) {
         providerMethods.put(
-            processingEnv.getElementUtils().getTypeElement(module.getKey()),
-            module.getValue());
+            processingEnv.getElementUtils().getTypeElement(module.getKey()), module.getValue());
       }
       for (Map.Entry<TypeElement, List<ExecutableElement>> module : providerMethods.entrySet()) {
         final TypeElement type = module.getKey();
         final String providesName = type.asType().toString();
         try {
-          // Attempt to get the annotation. If types are missing, this will
-          // throw IllegalStateException
+          // Attempt to get the annotation. If types are missing, this will throw
+          // IllegalStateException.
           Map<String, Object> parsedAnnotation = CodeGen.getAnnotation(Module.class, type);
           writeModuleAdapter(type, parsedAnnotation, module.getValue());
           delayedTypes.remove(providesName);


### PR DESCRIPTION
- InjectProcessor will now check all types needed when generating the injectAdapter and delay it until a subsequent pass if any classes are missing. If any types are still delayed in the final round an error message is sent.
- ProvidesProcessor is similar in that it attempts to read the @Module annotation and catches any IllegalStateException, delaying the type being handled until a subsequent round. If any types are still delayed in the final round, an error message is sent.
- FullGraphProcessor simply holds off until the final round of processing to execute.
