### PR TITLE
Making dagger compiler play nice with other codegen processors (#108)

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/FullGraphProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/FullGraphProcessor.java
@@ -15,20 +15,16 @@
  */
 package dagger.internal.codegen;
 
-import dagger.Module;
-import dagger.Provides;
-import dagger.internal.Binding;
-import dagger.internal.Linker;
-import dagger.internal.SetBinding;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
@@ -46,13 +42,19 @@ import javax.tools.FileObject;
 import javax.tools.JavaFileManager;
 import javax.tools.StandardLocation;
 
+import dagger.Module;
+import dagger.Provides;
+import dagger.internal.Binding;
+import dagger.internal.Linker;
+import dagger.internal.SetBinding;
+
 /**
  * Performs full graph analysis on a module.
  */
 @SupportedAnnotationTypes("dagger.Module")
 @SupportedSourceVersion(SourceVersion.RELEASE_6)
 public final class FullGraphProcessor extends AbstractProcessor {
-  private final Set<String> delayedModuleNames = new HashSet<String>();
+  private final Set<String> delayedModuleNames = new LinkedHashSet<String>();
 
   /**
    * Perform full-graph analysis on complete modules. This checks that all of
@@ -61,7 +63,7 @@ public final class FullGraphProcessor extends AbstractProcessor {
   @Override public boolean process(Set<? extends TypeElement> types, RoundEnvironment env) {
     try {
       if (!env.processingOver()) {
-        // Storing module names for later retrieval as the element instance remains invalid across
+        // Storing module names for later retrieval as the element instance is invalidated across
         // passes.
         for (Element e : env.getElementsAnnotatedWith(Module.class)) {
           delayedModuleNames.add(e.asType().toString());
@@ -69,7 +71,7 @@ public final class FullGraphProcessor extends AbstractProcessor {
         return true;
       }
 
-      Set<Element> modules = new HashSet<Element>();
+      Set<Element> modules = new LinkedHashSet<Element>();
       for (String moduleName : delayedModuleNames) {
         modules.add(processingEnv.getElementUtils().getTypeElement(moduleName));
       }
@@ -82,7 +84,6 @@ public final class FullGraphProcessor extends AbstractProcessor {
         TypeElement moduleType = (TypeElement) element;
         Map<String, Binding<?>> bindings = processCompleteModule(moduleType);
         writeDotFile(moduleType, bindings);
-        delayedModuleNames.remove(element.asType().toString());
       }
     } catch (IOException e) {
       error("Graph processing failed: " + e);


### PR DESCRIPTION
This is a follow up to the previous pull request (https://github.com/square/dagger/pull/111) of the same name.

Additional changes in this pull request:
- Addressed the use of static maps to maintain state across codegen passes
- Removed the verbose logging added in the previous pull request
- Simplified the FullGraphProcessor by storing type names instead of elements
- Added additional comments to explain why we're storing names instead of elements across passes
- Rebased on master to pick up latest commits
