### PR TITLE
Issue #130 - fixed ModuleAdapter bindings generation

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/ProvidesProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/ProvidesProcessor.java
@@ -129,7 +129,7 @@ public final class ProvidesProcessor extends AbstractProcessor {
         continue;
       }
 
-      List<ExecutableElement> methods = result.get(type);
+      List<ExecutableElement> methods = result.get(type.toString());
       if (methods == null) {
         methods = new ArrayList<ExecutableElement>();
         result.put(type.toString(), methods);


### PR DESCRIPTION
Generated ModuleAdapter always had one binding in getBindingsMethod() for some random Provides method.
This change fixes this problem.
