### PR TITLE
Fix dot-writer from NPEing when there are missing bindings. 

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/GraphVisualizer.java
+++ b/compiler/src/main/java/dagger/internal/codegen/GraphVisualizer.java
@@ -53,6 +53,9 @@ public final class GraphVisualizer {
       sourceBinding.getDependencies(dependencies, dependencies);
       for (Binding<?> targetBinding : dependencies) {
         String targetName = namesIndex.get(targetBinding);
+        if (targetName == null) {
+          targetName = "Unbound:" + targetBinding.provideKey;
+        }
         writer.edge(sourceName, targetName);
       }
     }


### PR DESCRIPTION
Fix dot-writer from NPEing when there are missing bindings.  Display the erroneous binding as unbound instead.
