### PR TITLE
Fix examples of including the dagger-compiler project for code-gen in maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ include `dagger-compiler-${dagger.version}.jar` in your build at compile time.
 
 In a Maven project, one would include the runtime in the dependencies section
 of your `pom.xml` (replacing `${dagger.version}` with the appropriate current
-release), and the `dagger-compiler` artifact as a dependency of the compiler
-plugin:
+release), and the `dagger-compiler` artifact as an "optional" dependency:
 
 ```xml
 <dependencies>
@@ -26,22 +25,13 @@ plugin:
     <artifactId>dagger</artifactId>
     <version>${dagger.version}</version>
   </dependency>
+  <dependency>
+    <groupId>com.squareup</groupId>
+    <artifactId>dagger-compiler</artifactId>
+    <version>${dagger.version}</version>
+    <optional>true</optional>
+  </dependency>
 </dependencies>
-
-<build>
-  <plugins>
-    <plugin>
-      <artifactId>maven-compiler-plugin</artifactId>
-      <dependencies>
-        <dependency>
-          <groupId>com.squareup</groupId>
-          <artifactId>dagger-compiler</artifactId>
-          <version>${dagger.version}</version>
-        </dependency>
-      </dependencies>
-    </plugin>
-  </plugins>
-</build>
 ```
 
 You can also find downloadable .jars on the [GitHub download page][2].

--- a/compiler/src/it/default-package-injected-type/pom.xml
+++ b/compiler/src/it/default-package-injected-type/pom.xml
@@ -33,7 +33,7 @@
       <groupId>com.squareup</groupId>
       <artifactId>dagger-compiler</artifactId>
       <version>${project.version}</version>
-      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
   </dependencies>
   <build>

--- a/compiler/src/it/extension-graph/pom.xml
+++ b/compiler/src/it/extension-graph/pom.xml
@@ -35,7 +35,7 @@
       <groupId>com.squareup</groupId>
       <artifactId>dagger-compiler</artifactId>
       <version>${project.version}</version>
-      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
   </dependencies>
   <build>

--- a/compiler/src/it/missing-at-inject-constructor/pom.xml
+++ b/compiler/src/it/missing-at-inject-constructor/pom.xml
@@ -35,7 +35,7 @@
       <groupId>com.squareup</groupId>
       <artifactId>dagger-compiler</artifactId>
       <version>${project.version}</version>
-      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
   </dependencies>
   <build>

--- a/compiler/src/it/same-provides-method-name/pom.xml
+++ b/compiler/src/it/same-provides-method-name/pom.xml
@@ -35,7 +35,7 @@
       <groupId>com.squareup</groupId>
       <artifactId>dagger-compiler</artifactId>
       <version>${project.version}</version>
-      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
   </dependencies>
   <build>

--- a/compiler/src/it/simple-missing-dependency-failure/pom.xml
+++ b/compiler/src/it/simple-missing-dependency-failure/pom.xml
@@ -35,7 +35,7 @@
       <groupId>com.squareup</groupId>
       <artifactId>dagger-compiler</artifactId>
       <version>${project.version}</version>
-      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
   </dependencies>
   <build>

--- a/compiler/src/it/uninjectable-supertype/pom.xml
+++ b/compiler/src/it/uninjectable-supertype/pom.xml
@@ -35,7 +35,7 @@
       <groupId>com.squareup</groupId>
       <artifactId>dagger-compiler</artifactId>
       <version>${project.version}</version>
-      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
   </dependencies>
   <build>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -34,21 +34,11 @@
       <artifactId>dagger</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>${project.version}</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>dagger-compiler</artifactId>
-            <version>${project.version}</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
The current example shows including dagger-compiler as a dependency of the maven-compiler-plugin.  This, however, results in no generation of sources written to the target/ directory.  

Using this approach results in both proper generation into `target/generated-sources/annotations/` but avoids the dependency on dagger-compiler becoming transitive. 
