### PR TITLE
Fix a crash in the dagger-compiler on parameterized injected types.

### DIFF
--- a/compiler/src/it/inject-parameterized-type/pom.xml
+++ b/compiler/src/it/inject-parameterized-type/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (C) 2013 Square, Inc.
+ Copyright (C) 2013 Google, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.squareup.dagger.tests</groupId>
+  <artifactId>inject-parameterized-type</artifactId>
+  <version>@dagger.version@</version>
+  <packaging>jar</packaging>
+  <name>Dagger Integration Test Basic</name>
+  <dependencies>
+    <dependency>
+      <groupId>com.squareup</groupId>
+      <artifactId>dagger</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>${project.version}</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration><source>1.5</source><target>1.5</target></configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/inject-parameterized-type/src/main/java/test/TestApp.java
+++ b/compiler/src/it/inject-parameterized-type/src/main/java/test/TestApp.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.Module;
+import dagger.ObjectGraph;
+import dagger.Provides;
+import javax.inject.Inject;
+
+class TestApp {
+  public static void main(String[] args) {
+    Subtype subtype = ObjectGraph.create(new TestModule()).get(Subtype.class);
+  }
+
+  static class Supertype<T> {
+    @Inject String s;
+  }
+
+  static class Subtype extends Supertype<Integer> {
+  }
+
+  @Module(entryPoints = Subtype.class)
+  static class TestModule {
+    @Provides String provideString() {
+      return "a";
+    }
+  }
+}

--- a/compiler/src/it/same-provides-method-name/invoker.properties
+++ b/compiler/src/it/same-provides-method-name/invoker.properties
@@ -1,1 +1,0 @@
-invoker.buildResult=success

--- a/compiler/src/main/java/dagger/internal/codegen/CodeGen.java
+++ b/compiler/src/main/java/dagger/internal/codegen/CodeGen.java
@@ -143,6 +143,7 @@ final class CodeGen {
         return null;
       }
       @Override public Void visitTypeVariable(TypeVariable typeVariable, Void v) {
+        result.append(typeVariable); // TypeVariable.toString() returns the name, like 'T'.
         return null;
       }
       @Override protected Void defaultAction(TypeMirror typeMirror, Void v) {

--- a/compiler/src/main/java/dagger/internal/codegen/InjectProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/InjectProcessor.java
@@ -112,7 +112,8 @@ public final class InjectProcessor extends AbstractProcessor {
     // First gather the set of classes that have @Inject-annotated members.
     Set<String> injectedTypeNames = new LinkedHashSet<String>();
     for (Element element : env.getElementsAnnotatedWith(Inject.class)) {
-      injectedTypeNames.add(element.getEnclosingElement().asType().toString());
+      TypeMirror type = element.getEnclosingElement().asType();
+      injectedTypeNames.add(CodeGen.rawTypeToString(type, '.'));
     }
     return injectedTypeNames;
   }


### PR DESCRIPTION
Otherwise dagger-compiler crashes like this:
  java.lang.NullPointerException
    at dagger.internal.codegen.InjectProcessor.getInjectedClass(InjectProcessor.java:128)
    at dagger.internal.codegen.InjectProcessor.process(InjectProcessor.java:68)
