### PR TITLE
Make `Binding<T>` default behaviour to do nothing on getDependencies()

### DIFF
--- a/core/src/main/java/dagger/internal/Binding.java
+++ b/core/src/main/java/dagger/internal/Binding.java
@@ -23,11 +23,7 @@ import javax.inject.Provider;
  * Injects a value of a specific type.
  */
 public abstract class Binding<T> implements Provider<T>, MembersInjector<T> {
-  public static final Binding<Object> UNRESOLVED = new Binding<Object>(null, null, false, null) {
-    @Override public void getDependencies(Set<Binding<?>> bindings, Set<Binding<?>> memBindings) {
-      // do nothing
-    }
-  };
+  public static final Binding<Object> UNRESOLVED = new Binding<Object>(null, null, false, null) { };
   protected static final boolean IS_SINGLETON = true;
   protected static final boolean NOT_SINGLETON = false;
 
@@ -90,7 +86,7 @@ public abstract class Binding<T> implements Provider<T>, MembersInjector<T> {
    *     injectMembers} method.
    */
   public void getDependencies(Set<Binding<?>> getBindings, Set<Binding<?>> injectMembersBindings) {
-    throw new UnsupportedOperationException(getClass().getName());
+    // Do nothing.  No override == no dependencies to contribute.
   }
 
   void setLinked() {

--- a/core/src/main/java/dagger/internal/BuiltInBinding.java
+++ b/core/src/main/java/dagger/internal/BuiltInBinding.java
@@ -15,7 +15,6 @@
  */
 package dagger.internal;
 
-import java.util.Set;
 
 /**
  * Injects a Provider or a MembersInjector.
@@ -46,7 +45,6 @@ final class BuiltInBinding<T> extends Binding<T> {
     return delegate;
   }
 
-  @Override public void getDependencies(Set<Binding<?>> get, Set<Binding<?>> injectMembers) {
-    // We don't add 'delegate' because it isn't actually used by get() or injectMembers().
-  }
+  // public void getDependencies() not overridden.
+  // We don't add 'delegate' because it isn't actually used by get() or injectMembers().
 }

--- a/core/src/main/java/dagger/internal/LazyBinding.java
+++ b/core/src/main/java/dagger/internal/LazyBinding.java
@@ -17,7 +17,6 @@
 package dagger.internal;
 
 import dagger.Lazy;
-import java.util.Set;
 
 /**
  * Injects a Lazy wrapper for a type T
@@ -57,8 +56,6 @@ final class LazyBinding<T> extends Binding<Lazy<T>> {
     };
   }
 
-  @Override public void getDependencies(
-      Set<Binding<?>> getBindings, Set<Binding<?>> injectMembersBindings) {
-    // We don't add 'delegate' because it isn't actually used by get() or injectMembers().
-  }
+  // public void getDependencies() not overridden.
+  // We don't add 'delegate' because it isn't actually used by get() or injectMembers().
 }

--- a/core/src/main/java/dagger/internal/Linker.java
+++ b/core/src/main/java/dagger/internal/Linker.java
@@ -332,6 +332,9 @@ public final class Linker {
       this.deferredKey = deferredKey;
       this.mustBeInjectable = mustBeInjectable;
     }
+    @Override public void getDependencies(Set<Binding<?>> get, Set<Binding<?>> injectMembers) {
+      throw new UnsupportedOperationException("Deferred bindings must resolve first.");
+    }
   }
 
 }


### PR DESCRIPTION
Fix regression introduced in #133 by making `Binding<T>` default behaviour to do nothing on `getDependencies()`
