### PR TITLE
Pass location with errors in codegen to have markers in editors in Eclipse

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/ReportingErrorHandler.java
+++ b/compiler/src/main/java/dagger/internal/codegen/ReportingErrorHandler.java
@@ -18,6 +18,7 @@ package dagger.internal.codegen;
 import dagger.internal.Linker;
 import java.util.List;
 import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic;
 
 /**
@@ -34,8 +35,10 @@ final class ReportingErrorHandler implements Linker.ErrorHandler {
   }
 
   @Override public void handleErrors(List<String> errors) {
+    TypeElement module = processingEnv.getElementUtils().getTypeElement(moduleName);
     for (String error : errors) {
-      processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, error + " for " + moduleName);
+      processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, error + " for " + moduleName,
+          module);
     }
   }
 }


### PR DESCRIPTION
Tried a few things in Eclipse (static `@Provides` method, private `@Provides` method, abstract module class, class with `@Provides` but without `Module`) and saw the markers.

I think I found a bug in `FullGraphProcessor` during my tests, where the included modules are assumed to have a `@Module` annotation, which can lead to an NPE if it's not the case.

Fixes issue #110
