### PR TITLE
Report error at codegen when child module is missing @Module annotation

### DIFF
--- a/compiler/src/it/include-non-module/pom.xml
+++ b/compiler/src/it/include-non-module/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (C) 2013 Square, Inc.
+ Copyright (C) 2013 Google, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.squareup.dagger.tests</groupId>
+  <artifactId>include-non-module</artifactId>
+  <version>@dagger.version@</version>
+  <packaging>jar</packaging>
+  <name>Dagger Integration Test Basic</name>
+  <dependencies>
+    <dependency>
+      <groupId>com.squareup</groupId>
+      <artifactId>dagger</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>${project.version}</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration><source>1.5</source><target>1.5</target></configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/include-non-module/src/main/java/test/TestApp.java
+++ b/compiler/src/it/include-non-module/src/main/java/test/TestApp.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.Module;
+import dagger.ObjectGraph;
+import dagger.Provides;
+import javax.inject.Inject;
+import java.lang.String;
+
+class TestApp {
+  public static void main(String[] args) {
+    TestApp app = ObjectGraph.create(new TestModule()).get(TestApp.class);
+  }
+
+  @Inject String s;
+
+  @Module(
+      entryPoints = TestApp.class,
+      includes = TestApp.class)
+  static class TestModule {
+    @Provides String provideString() {
+      return "a";
+    }
+  }
+}

--- a/compiler/src/main/java/dagger/internal/codegen/FullGraphProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/FullGraphProcessor.java
@@ -166,12 +166,18 @@ public final class FullGraphProcessor extends AbstractProcessor {
   }
 
   private void collectIncludesRecursively(TypeElement module, Map<String, TypeElement> result) {
+    Map<String, Object> annotation = CodeGen.getAnnotation(Module.class, module);
+    if (annotation == null) {
+      // TODO(tbroyer): pass annotation information
+      error("No @Module on " + module, module);
+      return;
+    }
+
     // Add the module.
     result.put(module.getQualifiedName().toString(), module);
 
     // Recurse for each included module.
     Types typeUtils = processingEnv.getTypeUtils();
-    Map<String, Object> annotation = CodeGen.getAnnotation(Module.class, module);
     List<Object> seedModules = new ArrayList<Object>();
     seedModules.addAll(Arrays.asList((Object[]) annotation.get("includes")));
     if (!annotation.get("addsTo").equals(Void.class)) seedModules.add(annotation.get("addsTo"));

--- a/core/src/test/java/dagger/ModuleIncludesTest.java
+++ b/core/src/test/java/dagger/ModuleIncludesTest.java
@@ -177,4 +177,14 @@ public final class ModuleIncludesTest {
     assertThat(objectGraph.get(A.class)).isNotNull();
     assertThat(objectGraph.get(B.class).a).isNotNull();
   }
+
+  static class ModuleMissingModuleAnnotation {}
+
+  @Module(includes = ModuleMissingModuleAnnotation.class)
+  static class ChildModuleMissingModuleAnnotation {}
+
+  @Test(expected = IllegalArgumentException.class)
+  public void childModuleMissingModuleAnnotation() {
+    ObjectGraph.create(new ChildModuleMissingModuleAnnotation());
+  }
 }


### PR DESCRIPTION
It previously failed with an NPE.
Also adds a test for the reflective backend.
