### PR TITLE
Add `@RunWith(Junit4.class)` annotations

### DIFF
--- a/androidmanifest/src/test/java/dagger/androidmanifest/ModuleGeneratorTest.java
+++ b/androidmanifest/src/test/java/dagger/androidmanifest/ModuleGeneratorTest.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
@@ -30,6 +32,7 @@ import static dagger.androidmanifest.ModuleGenerator.cleanActivityName;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
+@RunWith(JUnit4.class)
 public final class ModuleGeneratorTest {
   private final ModuleGenerator generator = new ModuleGenerator();
   private final StringWriter stringWriter = new StringWriter();

--- a/compiler/src/test/java/dagger/internal/codegen/DotWriterTest.java
+++ b/compiler/src/test/java/dagger/internal/codegen/DotWriterTest.java
@@ -18,9 +18,12 @@ package dagger.internal.codegen;
 import java.io.IOException;
 import java.io.StringWriter;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static org.fest.assertions.Assertions.assertThat;
 
+@RunWith(JUnit4.class)
 public final class DotWriterTest {
   private final StringWriter stringWriter = new StringWriter();
   private final DotWriter dotWriter = new DotWriter(stringWriter);

--- a/compiler/src/test/java/dagger/internal/codegen/GraphVisualizerTest.java
+++ b/compiler/src/test/java/dagger/internal/codegen/GraphVisualizerTest.java
@@ -21,9 +21,12 @@ import java.util.Map;
 import java.util.Set;
 import javax.inject.Named;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static org.fest.assertions.Assertions.assertThat;
 
+@RunWith(JUnit4.class)
 public final class GraphVisualizerTest {
   private final GraphVisualizer graphVisualizer = new GraphVisualizer();
 

--- a/core/src/test/java/dagger/ExtensionTest.java
+++ b/core/src/test/java/dagger/ExtensionTest.java
@@ -20,10 +20,13 @@ import java.util.Arrays;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 
+@RunWith(JUnit4.class)
 public final class ExtensionTest {
   @Singleton
   static class A {

--- a/core/src/test/java/dagger/InjectStaticsTest.java
+++ b/core/src/test/java/dagger/InjectStaticsTest.java
@@ -18,9 +18,12 @@ package dagger;
 import javax.inject.Inject;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static org.fest.assertions.Assertions.assertThat;
 
+@RunWith(JUnit4.class)
 public final class InjectStaticsTest {
   @Before public void setUp() {
     InjectsOneField.staticField = null;

--- a/core/src/test/java/dagger/InjectionOfLazyTest.java
+++ b/core/src/test/java/dagger/InjectionOfLazyTest.java
@@ -20,6 +20,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -27,6 +29,7 @@ import static org.junit.Assert.assertNull;
 /**
  * Tests of injection of Lazy<T> bindings.
  */
+@RunWith(JUnit4.class)
 public final class InjectionOfLazyTest {
   @Test public void lazyValueCreation() {
     final AtomicInteger counter = new AtomicInteger();

--- a/core/src/test/java/dagger/InjectionTest.java
+++ b/core/src/test/java/dagger/InjectionTest.java
@@ -26,11 +26,14 @@ import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+@RunWith(JUnit4.class)
 public final class InjectionTest {
   @Test public void basicInjection() {
     class TestEntryPoint {
@@ -497,10 +500,11 @@ public final class InjectionTest {
     }
   }
 
-  @Test public void noConstructorInjectionsForClassesWithTypeParameters() {
-    class Parameterized<T> {
+  static class Parameterized<T> {
       @Inject String string;
     }
+
+  @Test public void noConstructorInjectionsForClassesWithTypeParameters() {
 
     class TestEntryPoint {
       @Inject Parameterized<Long> parameterized;

--- a/core/src/test/java/dagger/LazyInjectionTest.java
+++ b/core/src/test/java/dagger/LazyInjectionTest.java
@@ -17,9 +17,12 @@ package dagger;
 
 import javax.inject.Inject;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static org.fest.assertions.Assertions.assertThat;
 
+@RunWith(JUnit4.class)
 public final class LazyInjectionTest {
   @Test public void getLazyDoesNotCauseEntryPointsToBeLoaded() {
     @Module(entryPoints = LazyEntryPoint.class)

--- a/core/src/test/java/dagger/MembersInjectorTest.java
+++ b/core/src/test/java/dagger/MembersInjectorTest.java
@@ -19,6 +19,8 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.fail;
@@ -27,6 +29,7 @@ import static org.junit.Assert.fail;
  * Tests MembersInjector injection, and how object graph features interact with
  * types unconstructable types (types that support members injection only).
  */
+@RunWith(JUnit4.class)
 public final class MembersInjectorTest {
   @Test public void injectMembers() {
     class TestEntryPoint {

--- a/core/src/test/java/dagger/ModuleIncludesTest.java
+++ b/core/src/test/java/dagger/ModuleIncludesTest.java
@@ -17,10 +17,13 @@ package dagger;
 
 import javax.inject.Inject;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
+@RunWith(JUnit4.class)
 public final class ModuleIncludesTest {
   static class TestEntryPoint {
     @Inject String s;
@@ -73,9 +76,6 @@ public final class ModuleIncludesTest {
   }
 
   @Test public void childModuleWithBinding() {
-    class TestEntryPoint {
-      @Inject String s;
-    }
 
     @Module(
         entryPoints = TestEntryPoint.class,
@@ -95,9 +95,6 @@ public final class ModuleIncludesTest {
   }
 
   @Test public void childModuleWithChildModule() {
-    class TestEntryPoint {
-      @Inject String s;
-    }
 
     @Module(
         entryPoints = TestEntryPoint.class,
@@ -138,9 +135,6 @@ public final class ModuleIncludesTest {
   }
 
   @Test public void childModuleWithManualConstruction() {
-    class TestEntryPoint {
-      @Inject String s;
-    }
 
     @Module(
         entryPoints = TestEntryPoint.class,

--- a/core/src/test/java/dagger/ProblemDetectorTest.java
+++ b/core/src/test/java/dagger/ProblemDetectorTest.java
@@ -17,9 +17,12 @@ package dagger;
 
 import javax.inject.Inject;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static org.junit.Assert.fail;
 
+@RunWith(JUnit4.class)
 public final class ProblemDetectorTest {
   @Test public void atInjectCircularDependenciesDetected() {
     class TestEntryPoint {

--- a/core/src/test/java/dagger/SetBindingTest.java
+++ b/core/src/test/java/dagger/SetBindingTest.java
@@ -27,6 +27,8 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static dagger.Provides.Type.SET;
 import static org.fest.assertions.Assertions.assertThat;
@@ -34,6 +36,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+@RunWith(JUnit4.class)
 public final class SetBindingTest {
   @Test public void multiValueBindings_SingleModule() {
     class TestEntryPoint {

--- a/core/src/test/java/dagger/internal/KeysTest.java
+++ b/core/src/test/java/dagger/internal/KeysTest.java
@@ -25,10 +25,13 @@ import java.util.Map;
 import javax.inject.Named;
 import javax.inject.Provider;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static dagger.Provides.Type.SET;
 import static org.fest.assertions.Assertions.assertThat;
 
+@RunWith(JUnit4.class)
 public final class KeysTest {
   int primitive;
   @Test public void lonePrimitiveGetsBoxed() throws NoSuchFieldException {


### PR DESCRIPTION
Add `@RunWith(Junit4.class)` annotations so Dagger can build from source inside customers' codebases and run in non-maven hosted test runners.  Also, pull out a very few non-static inner types from test methods where they are defined.  Some compilers have some problems with this, notably pre Java7u2 and many Java6 compilers, that didn't have a bug fixed.  
