### PR TITLE
Use SourceVersion.latestSupported() to avoid warning with JDK 7.

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/FullGraphProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/FullGraphProcessor.java
@@ -34,7 +34,6 @@ import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.inject.Singleton;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
@@ -52,9 +51,12 @@ import javax.tools.StandardLocation;
  * Performs full graph analysis on a module.
  */
 @SupportedAnnotationTypes("dagger.Module")
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
 public final class FullGraphProcessor extends AbstractProcessor {
   private final Set<String> delayedModuleNames = new LinkedHashSet<String>();
+
+  @Override public SourceVersion getSupportedSourceVersion() {
+    return SourceVersion.latestSupported();
+  }
 
   /**
    * Perform full-graph analysis on complete modules. This checks that all of

--- a/compiler/src/main/java/dagger/internal/codegen/InjectProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/InjectProcessor.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
@@ -58,9 +57,12 @@ import static java.lang.reflect.Modifier.PUBLIC;
  * {@literal @}{@code Inject}-annotated members of a class.
  */
 @SupportedAnnotationTypes("javax.inject.Inject")
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
 public final class InjectProcessor extends AbstractProcessor {
   private final Set<String> remainingTypeNames = new LinkedHashSet<String>();
+
+  @Override public SourceVersion getSupportedSourceVersion() {
+    return SourceVersion.latestSupported();
+  }
 
   @Override public boolean process(Set<? extends TypeElement> types, RoundEnvironment env) {
     remainingTypeNames.addAll(getInjectedClassNames(env));

--- a/compiler/src/main/java/dagger/internal/codegen/ProvidesProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/ProvidesProcessor.java
@@ -35,7 +35,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 import javax.lang.model.SourceVersion;
@@ -62,12 +61,15 @@ import static java.lang.reflect.Modifier.STATIC;
  * for each {@code @Provides} method of a target class.
  */
 @SupportedAnnotationTypes({ "dagger.Provides", "dagger.Module" })
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
 public final class ProvidesProcessor extends AbstractProcessor {
   private final LinkedHashMap<String, List<ExecutableElement>> remainingTypes =
       new LinkedHashMap<String, List<ExecutableElement>>();
   private static final String BINDINGS_MAP = JavaWriter.type(
       Map.class, String.class.getCanonicalName(), Binding.class.getCanonicalName() + "<?>");
+
+  @Override public SourceVersion getSupportedSourceVersion() {
+    return SourceVersion.latestSupported();
+  }
 
   // TODO: include @Provides methods from the superclass
   @Override public boolean process(Set<? extends TypeElement> types, RoundEnvironment env) {


### PR DESCRIPTION
When using dagger-compiler in a Java 7 project, the compiler used to issue
a "Supported source version 'RELEASE_6' from annotation processor
'dagger.internal.codegen.InjectProcessor' less than -source '1.7'" warning.

See also http://stackoverflow.com/a/8188860/116472 and hibernate/hibernate-metamodelgen@d8ce150760f579a9c0499376cc8471c80d75ddda, among others (I trust JBoss more than others about using `latestSupported()` rather than `latest()`, maybe I'm wrong).
