### PR TITLE
Recommend scope=provided to include dagger-compiler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ release), and the `dagger-compiler` artifact as an "optional" dependency:
     <groupId>com.squareup</groupId>
     <artifactId>dagger-compiler</artifactId>
     <version>${dagger.version}</version>
-    <optional>true</optional>
+    <scope>provided</scope>
   </dependency>
 </dependencies>
 ```

--- a/website/index.html
+++ b/website/index.html
@@ -375,21 +375,13 @@ public class CoffeeMakerTest {
     &lt;artifactId>dagger&lt;/artifactId>
     &lt;version>${dagger.version}&lt;/version>
   &lt;/dependency>
+  &lt;dependency>
+    &lt;groupId>com.squareup&lt;/groupId>
+    &lt;artifactId>dagger-compiler&lt;/artifactId>
+    &lt;version>${dagger.version}&lt;/version>
+    &lt;scope>provided&lt;/scope>
+  &lt;/dependency>
 &lt;/dependencies>
-&lt;build>
-  &lt;plugins>
-    &lt;plugin>
-      &lt;artifactId>maven-compiler-plugin&lt;/artifactId>
-      &lt;dependencies>
-        &lt;dependency>
-          &lt;groupId>com.squareup&lt;/groupId>
-          &lt;artifactId>dagger-compiler&lt;/artifactId>
-          &lt;version>${dagger.version}&lt;/version>
-        &lt;/dependency>
-      &lt;/dependencies>
-    &lt;/plugin>
-  &lt;/plugins>
-&lt;/build>
 </pre>
 
 


### PR DESCRIPTION
Using the compiler plugin wasn't picking up the code gen plugin
reliably for me. Using optional means that everything that uses
dagger-compiler needs an explicit dependency, even if they're
depending on dagger implicitly.
