### PR TITLE
Add restrictions around injectable targets.

### DIFF
--- a/compiler/src/it/method-injection/invoker.properties
+++ b/compiler/src/it/method-injection/invoker.properties
@@ -1,0 +1,1 @@
+invoker.buildResult=failure

--- a/compiler/src/it/method-injection/pom.xml
+++ b/compiler/src/it/method-injection/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2013 Square, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>method-injection</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.0</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+          <!-- workaround for http://jira.codehaus.org/browse/MCOMPILER-202 -->
+          <forceJavacCompilerUse>true</forceJavacCompilerUse>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>@dagger.groupId@</groupId>
+            <artifactId>dagger-compiler</artifactId>
+            <version>@dagger.version@</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/method-injection/src/main/java/test/TestApp.java
+++ b/compiler/src/it/method-injection/src/main/java/test/TestApp.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import javax.inject.Inject;
+
+class TestApp {
+  @Inject public void doThings(Object things) {
+  }
+}

--- a/compiler/src/it/method-injection/verify.bsh
+++ b/compiler/src/it/method-injection/verify.bsh
@@ -1,0 +1,6 @@
+import dagger.testing.it.BuildLogValidator;
+import java.io.File;
+
+File buildLog = new File(basedir, "build.log");
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Method injection is not supported: test.TestApp.doThings"});

--- a/compiler/src/it/private-inject/invoker.properties
+++ b/compiler/src/it/private-inject/invoker.properties
@@ -1,0 +1,1 @@
+invoker.buildResult=failure

--- a/compiler/src/it/private-inject/pom.xml
+++ b/compiler/src/it/private-inject/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2013 Square, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>private-inject</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.0</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+          <!-- workaround for http://jira.codehaus.org/browse/MCOMPILER-202 -->
+          <forceJavacCompilerUse>true</forceJavacCompilerUse>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>@dagger.groupId@</groupId>
+            <artifactId>dagger-compiler</artifactId>
+            <version>@dagger.version@</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/private-inject/src/main/java/test/TestApp.java
+++ b/compiler/src/it/private-inject/src/main/java/test/TestApp.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import javax.inject.Inject;
+
+class TestApp {
+  @Inject private Object nope;
+}

--- a/compiler/src/it/private-inject/src/main/java/test/TestFoo.java
+++ b/compiler/src/it/private-inject/src/main/java/test/TestFoo.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import javax.inject.Inject;
+
+class TestFoo {
+  @Inject private TestFoo() {
+  }
+}

--- a/compiler/src/it/private-inject/verify.bsh
+++ b/compiler/src/it/private-inject/verify.bsh
@@ -1,0 +1,8 @@
+import dagger.testing.it.BuildLogValidator;
+import java.io.File;
+
+File buildLog = new File(basedir, "build.log");
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Can't inject a private field or constructor: test.TestApp.nope"});
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Can't inject a private field or constructor: test.TestFoo.TestFoo()"});

--- a/core/src/main/java/dagger/internal/plugins/reflect/ReflectiveAtInjectBinding.java
+++ b/core/src/main/java/dagger/internal/plugins/reflect/ReflectiveAtInjectBinding.java
@@ -156,6 +156,9 @@ final class ReflectiveAtInjectBinding<T> extends Binding<T> {
         if (!field.isAnnotationPresent(Inject.class) || Modifier.isStatic(field.getModifiers())) {
           continue;
         }
+        if ((field.getModifiers() & Modifier.PRIVATE) != 0) {
+          throw new IllegalStateException("Can't inject private field: " + field);
+        }
         field.setAccessible(true);
         injectedFields.add(field);
         keys.add(Keys.get(field.getGenericType(), field.getAnnotations(), field));
@@ -189,6 +192,10 @@ final class ReflectiveAtInjectBinding<T> extends Binding<T> {
     int parameterCount;
     String provideKey;
     if (injectedConstructor != null) {
+      if ((injectedConstructor.getModifiers() & Modifier.PRIVATE) != 0) {
+        throw new IllegalStateException("Can't inject private constructor: " + injectedConstructor);
+      }
+
       provideKey = Keys.get(type);
       injectedConstructor.setAccessible(true);
       Type[] types = injectedConstructor.getGenericParameterTypes();

--- a/core/src/test/java/dagger/InjectionTest.java
+++ b/core/src/test/java/dagger/InjectionTest.java
@@ -750,4 +750,33 @@ public final class InjectionTest {
     assertThat(extension.get(SingletonLinkedFromExtension.class).c).isSameAs(root.get(C.class));
   }
 
+  @Test(expected = IllegalStateException.class)
+  public void privateFieldsFail() {
+    class Test {
+      @Inject private Object nope;
+    }
+
+    @Module(entryPoints = Test.class)
+    class TestModule {
+      @Provides Object provideObject() {
+        return null;
+      }
+    }
+
+    ObjectGraph.create(new TestModule()).inject(new Test());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void privateConstructorsFail() {
+    class Test {
+      @Inject private Test() {
+      }
+    }
+
+    @Module(entryPoints = Test.class)
+    class TestModule {
+    }
+
+    ObjectGraph.create(new TestModule()).get(Test.class);
+  }
 }


### PR DESCRIPTION
- Private fields are not supported.
- Private constructors are not supported.
- Methods are not supported.

Closes #181. Closes #113. Closes #112.
