### PR TITLE
Move back to optional dependency for the dagger-compiler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ include `dagger-compiler-${dagger.version}.jar` in your build at compile time.
 
 In a Maven project, one would include the runtime in the dependencies section
 of your `pom.xml` (replacing `${dagger.version}` with the appropriate current
-release), and the `dagger-compiler` artifact as an "optional" dependency:
+release), and the `dagger-compiler` artifact as an "optional" or "provided"
+dependency:
 
 ```xml
 <dependencies>
@@ -25,27 +26,13 @@ release), and the `dagger-compiler` artifact as an "optional" dependency:
     <artifactId>dagger</artifactId>
     <version>${dagger.version}</version>
   </dependency>
+  <dependency>
+    <groupId>com.squareup</groupId>
+    <artifactId>dagger-compiler</artifactId>
+    <version>${dagger.version}</version>
+    <optional>true</optional>
+  </dependency>
 </dependencies>
-
-<build>
-  <plugins>
-    <plugin>
-      <artifactId>maven-compiler-plugin</artifactId>
-      <version>3.0</version>
-      <configuration>
-        <!-- Workaround for http://jira.codehaus.org/browse/MCOMPILER-202. -->
-        <forceJavacCompilerUse>true</forceJavacCompilerUse>
-      </configuration>
-      <dependencies>
-        <dependency>
-          <groupId>com.squareup</groupId>
-          <artifactId>dagger-compiler</artifactId>
-          <version>${dagger.version}</version>
-        </dependency>
-      </dependencies>
-    </plugin>
-  </plugins>
-</build>
 ```
 
 You can also find downloadable .jars on the [GitHub download page][2].

--- a/compiler/src/it/cyclic-deps/pom.xml
+++ b/compiler/src/it/cyclic-deps/pom.xml
@@ -30,25 +30,18 @@
       <artifactId>dagger</artifactId>
       <version>@dagger.version@</version>
     </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
-        <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
-          <!-- workaround for http://jira.codehaus.org/browse/MCOMPILER-202 -->
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>@dagger.groupId@</groupId>
-            <artifactId>dagger-compiler</artifactId>
-            <version>@dagger.version@</version>
-          </dependency>
-        </dependencies>
+        <configuration><source>1.5</source><target>1.5</target></configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/default-package-injected-type/pom.xml
+++ b/compiler/src/it/default-package-injected-type/pom.xml
@@ -30,25 +30,18 @@
       <artifactId>dagger</artifactId>
       <version>@dagger.version@</version>
     </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
-        <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
-          <!-- workaround for http://jira.codehaus.org/browse/MCOMPILER-202 -->
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>@dagger.groupId@</groupId>
-            <artifactId>dagger-compiler</artifactId>
-            <version>@dagger.version@</version>
-          </dependency>
-        </dependencies>
+        <configuration><source>1.5</source><target>1.5</target></configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/extension-graph/pom.xml
+++ b/compiler/src/it/extension-graph/pom.xml
@@ -30,25 +30,18 @@
       <artifactId>dagger</artifactId>
       <version>@dagger.version@</version>
     </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
-        <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
-          <!-- workaround for http://jira.codehaus.org/browse/MCOMPILER-202 -->
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>@dagger.groupId@</groupId>
-            <artifactId>dagger-compiler</artifactId>
-            <version>@dagger.version@</version>
-          </dependency>
-        </dependencies>
+        <configuration><source>1.5</source><target>1.5</target></configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/include-non-module/pom.xml
+++ b/compiler/src/it/include-non-module/pom.xml
@@ -30,25 +30,18 @@
       <artifactId>dagger</artifactId>
       <version>@dagger.version@</version>
     </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
-        <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
-          <!-- workaround for http://jira.codehaus.org/browse/MCOMPILER-202 -->
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>@dagger.groupId@</groupId>
-            <artifactId>dagger-compiler</artifactId>
-            <version>@dagger.version@</version>
-          </dependency>
-        </dependencies>
+        <configuration><source>1.5</source><target>1.5</target></configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/inject-parameterized-type/pom.xml
+++ b/compiler/src/it/inject-parameterized-type/pom.xml
@@ -30,25 +30,18 @@
       <artifactId>dagger</artifactId>
       <version>@dagger.version@</version>
     </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
-        <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
-          <!-- workaround for http://jira.codehaus.org/browse/MCOMPILER-202 -->
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>@dagger.groupId@</groupId>
-            <artifactId>dagger-compiler</artifactId>
-            <version>@dagger.version@</version>
-          </dependency>
-        </dependencies>
+        <configuration><source>1.5</source><target>1.5</target></configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/inner-classes-complaint-injection/pom.xml
+++ b/compiler/src/it/inner-classes-complaint-injection/pom.xml
@@ -29,25 +29,18 @@
       <artifactId>dagger</artifactId>
       <version>@dagger.version@</version>
     </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
-        <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
-          <!-- workaround for http://jira.codehaus.org/browse/MCOMPILER-202 -->
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>@dagger.groupId@</groupId>
-            <artifactId>dagger-compiler</artifactId>
-            <version>@dagger.version@</version>
-          </dependency>
-        </dependencies>
+        <configuration><source>1.5</source><target>1.5</target></configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/method-injection/pom.xml
+++ b/compiler/src/it/method-injection/pom.xml
@@ -28,25 +28,21 @@
       <artifactId>dagger</artifactId>
       <version>@dagger.version@</version>
     </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>
-          <!-- workaround for http://jira.codehaus.org/browse/MCOMPILER-202 -->
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>@dagger.groupId@</groupId>
-            <artifactId>dagger-compiler</artifactId>
-            <version>@dagger.version@</version>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/missing-at-inject-constructor/pom.xml
+++ b/compiler/src/it/missing-at-inject-constructor/pom.xml
@@ -30,25 +30,18 @@
       <artifactId>dagger</artifactId>
       <version>@dagger.version@</version>
     </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
-        <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
-          <!-- workaround for http://jira.codehaus.org/browse/MCOMPILER-202 -->
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>@dagger.groupId@</groupId>
-            <artifactId>dagger-compiler</artifactId>
-            <version>@dagger.version@</version>
-          </dependency>
-        </dependencies>
+        <configuration><source>1.5</source><target>1.5</target></configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/multiple-provides-methods/pom.xml
+++ b/compiler/src/it/multiple-provides-methods/pom.xml
@@ -30,25 +30,18 @@
       <artifactId>dagger</artifactId>
       <version>@dagger.version@</version>
     </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
-        <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
-          <!-- workaround for http://jira.codehaus.org/browse/MCOMPILER-202 -->
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>@dagger.groupId@</groupId>
-            <artifactId>dagger-compiler</artifactId>
-            <version>@dagger.version@</version>
-          </dependency>
-        </dependencies>
+        <configuration><source>1.5</source><target>1.5</target></configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/private-inject/pom.xml
+++ b/compiler/src/it/private-inject/pom.xml
@@ -28,25 +28,21 @@
       <artifactId>dagger</artifactId>
       <version>@dagger.version@</version>
     </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>
-          <!-- workaround for http://jira.codehaus.org/browse/MCOMPILER-202 -->
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>@dagger.groupId@</groupId>
-            <artifactId>dagger-compiler</artifactId>
-            <version>@dagger.version@</version>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/provides-method-with-throws-clause/pom.xml
+++ b/compiler/src/it/provides-method-with-throws-clause/pom.xml
@@ -30,25 +30,18 @@
       <artifactId>dagger</artifactId>
       <version>@dagger.version@</version>
     </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
-        <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
-          <!-- workaround for http://jira.codehaus.org/browse/MCOMPILER-202 -->
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>@dagger.groupId@</groupId>
-            <artifactId>dagger-compiler</artifactId>
-            <version>@dagger.version@</version>
-          </dependency>
-        </dependencies>
+        <configuration><source>1.5</source><target>1.5</target></configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/same-provides-method-name/pom.xml
+++ b/compiler/src/it/same-provides-method-name/pom.xml
@@ -30,25 +30,18 @@
       <artifactId>dagger</artifactId>
       <version>@dagger.version@</version>
     </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
-        <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
-          <!-- workaround for http://jira.codehaus.org/browse/MCOMPILER-202 -->
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>@dagger.groupId@</groupId>
-            <artifactId>dagger-compiler</artifactId>
-            <version>@dagger.version@</version>
-          </dependency>
-        </dependencies>
+        <configuration><source>1.5</source><target>1.5</target></configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/simple-missing-dependency-failure/pom.xml
+++ b/compiler/src/it/simple-missing-dependency-failure/pom.xml
@@ -29,27 +29,20 @@
     <dependency>
       <groupId>@dagger.groupId@</groupId>
       <artifactId>dagger</artifactId>
-      <version>@dagger.version@</version>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>${project.version}</version>
+      <optional>true</optional>
     </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
-        <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
-          <!-- workaround for http://jira.codehaus.org/browse/MCOMPILER-202 -->
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>@dagger.groupId@</groupId>
-            <artifactId>dagger-compiler</artifactId>
-            <version>@dagger.version@</version>
-          </dependency>
-        </dependencies>
+        <configuration><source>1.5</source><target>1.5</target></configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/uninjectable-supertype/pom.xml
+++ b/compiler/src/it/uninjectable-supertype/pom.xml
@@ -30,25 +30,18 @@
       <artifactId>dagger</artifactId>
       <version>@dagger.version@</version>
     </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
-        <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
-          <!-- workaround for http://jira.codehaus.org/browse/MCOMPILER-202 -->
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>@dagger.groupId@</groupId>
-            <artifactId>dagger-compiler</artifactId>
-            <version>@dagger.version@</version>
-          </dependency>
-        </dependencies>
+        <configuration><source>1.5</source><target>1.5</target></configuration>
       </plugin>
     </plugins>
   </build>

--- a/examples/simple/pom.xml
+++ b/examples/simple/pom.xml
@@ -32,6 +32,12 @@
       <artifactId>dagger</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.squareup.dagger</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>${project.version}</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -41,16 +47,7 @@
           <compilerArgument>-Xlint:all</compilerArgument>
           <showWarnings>true</showWarnings>
           <showDeprecation>true</showDeprecation>
-          <!-- workaround for http://jira.codehaus.org/browse/MCOMPILER-202 -->
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>com.squareup.dagger</groupId>
-            <artifactId>dagger-compiler</artifactId>
-            <version>${project.version}</version>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
+        <version>2.5</version>
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>

--- a/website/index.html
+++ b/website/index.html
@@ -366,7 +366,7 @@ public class CoffeeMakerTest {
 
 <p>You will need to include the <code>dagger-${dagger.version}.jar</code> in your application's runtime.  In order to activate code generation you will need to include <code>dagger-compiler-${dagger.version}.jar</code> in your build at compile time.</p>
 
-<p>In a Maven project, one would include the runtime in the dependencies section of your <code>pom.xml</code> (replacing <code>${dagger.version}</code> with the appropriate current release), and the <code>dagger-compiler</code> artifact as a dependency of the compiler plugin:</p>
+<p>In a Maven project, one would include the runtime in the dependencies section of your <code>pom.xml</code> (replacing <code>${dagger.version}</code> with the appropriate current release), and the <code>dagger-compiler</code> artifact as an "optional" or "provided" dependency:</p>
 
 <pre class="prettyprint">
 &lt;dependencies>
@@ -375,26 +375,13 @@ public class CoffeeMakerTest {
     &lt;artifactId>dagger&lt;/artifactId>
     &lt;version>${dagger.version}&lt;/version>
   &lt;/dependency>
+  &lt;dependency>
+    &lt;groupId>com.squareup&lt;/groupId>
+    &lt;artifactId>dagger-compiler&lt;/artifactId>
+    &lt;version>${dagger.version}&lt;/version>
+    &lt;optional>true&lt;/optional>
+  &lt;/dependency>
 &lt;/dependencies>
-&lt;build>
-  &lt;plugins>
-    &lt;plugin>
-      &lt;artifactId>maven-compiler-plugin&lt;/artifactId>
-      &lt;version>3.0&lt;/version>
-      &lt;configuration>
-        &lt;!-- Workaround for http://jira.codehaus.org/browse/MCOMPILER-202. -->
-        &lt;forceJavacCompilerUse>true&lt;/forceJavacCompilerUse>
-      &lt;/configuration>
-      &lt;dependencies>
-        &lt;dependency>
-          &lt;groupId>com.squareup&lt;/groupId>
-          &lt;artifactId>dagger-compiler&lt;/artifactId>
-          &lt;version>${dagger.version}&lt;/version>
-        &lt;/dependency>
-      &lt;/dependencies>
-    &lt;/plugin>
-  &lt;/plugins>
-&lt;/build>
 </pre>
 
 


### PR DESCRIPTION
This reverts commits 2014bce8e79f7bdba4fcaa4f581e6189543ded00
and f784b96520d0a408ac76b5b187e7bb9dc5c32ff1, with a few other
changes in the documentation and IT tests added afterwards.

Closes #194
