### PR TITLE
Revert missed integration test to old dagger-compiler inclusion strategy.

### DIFF
--- a/compiler/src/it/module-type-validation/pom.xml
+++ b/compiler/src/it/module-type-validation/pom.xml
@@ -28,25 +28,21 @@
       <artifactId>dagger</artifactId>
       <version>@dagger.version@</version>
     </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>
-          <!-- workaround for http://jira.codehaus.org/browse/MCOMPILER-202 -->
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>@dagger.groupId@</groupId>
-            <artifactId>dagger-compiler</artifactId>
-            <version>@dagger.version@</version>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Closes #200.
