### PR TITLE
Update coffee example URL

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -17,7 +17,7 @@ layout: default
 <p>For more information, <a href="http://www.infoq.com/presentations/Dagger">watch an introductory talk</a> by Jesse Wilson at QCon 2012.</p>
 
 <h3>Using Dagger</h3>
-<p>We'll demonstrate dependency injection and Dagger by building a coffee maker. For complete sample code that you can compile and run, see Dagger's <a href="https://github.com/square/dagger/tree/master/example/src/main/java/coffee">coffee example</a>.</p>
+<p>We'll demonstrate dependency injection and Dagger by building a coffee maker. For complete sample code that you can compile and run, see Dagger's <a href="https://github.com/square/dagger/tree/master/examples/simple/src/main/java/coffee">coffee example</a>.</p>
 
 <h4>Declaring Dependencies</h4>
 


### PR DESCRIPTION
Replace link in `website/index.html`, as structure for examples was changed in  ad36309d84bcf8b922eeff10a647f328091258f9
