### PR TITLE
Use maven-compiler-plugin 3.1 in compiler IT tests to fix platform-dependent issues

### DIFF
--- a/compiler/src/it/cyclic-deps/pom.xml
+++ b/compiler/src/it/cyclic-deps/pom.xml
@@ -41,7 +41,11 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration><source>1.5</source><target>1.5</target></configuration>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/cyclic-module-includes/pom.xml
+++ b/compiler/src/it/cyclic-module-includes/pom.xml
@@ -41,7 +41,11 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration><source>1.5</source><target>1.5</target></configuration>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/default-package-injected-type/pom.xml
+++ b/compiler/src/it/default-package-injected-type/pom.xml
@@ -41,7 +41,11 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration><source>1.5</source><target>1.5</target></configuration>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/extension-graph/pom.xml
+++ b/compiler/src/it/extension-graph/pom.xml
@@ -41,7 +41,11 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration><source>1.5</source><target>1.5</target></configuration>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/include-non-module/pom.xml
+++ b/compiler/src/it/include-non-module/pom.xml
@@ -41,7 +41,11 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration><source>1.5</source><target>1.5</target></configuration>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/inject-parameterized-type/pom.xml
+++ b/compiler/src/it/inject-parameterized-type/pom.xml
@@ -41,7 +41,11 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration><source>1.5</source><target>1.5</target></configuration>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/inner-classes-complaint-injection/pom.xml
+++ b/compiler/src/it/inner-classes-complaint-injection/pom.xml
@@ -40,7 +40,11 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration><source>1.5</source><target>1.5</target></configuration>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/method-injection/pom.xml
+++ b/compiler/src/it/method-injection/pom.xml
@@ -39,6 +39,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>

--- a/compiler/src/it/missing-at-inject-constructor/pom.xml
+++ b/compiler/src/it/missing-at-inject-constructor/pom.xml
@@ -41,7 +41,11 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration><source>1.5</source><target>1.5</target></configuration>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/module-type-validation/pom.xml
+++ b/compiler/src/it/module-type-validation/pom.xml
@@ -39,6 +39,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>

--- a/compiler/src/it/multiple-provides-methods/pom.xml
+++ b/compiler/src/it/multiple-provides-methods/pom.xml
@@ -41,7 +41,11 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration><source>1.5</source><target>1.5</target></configuration>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/private-inject/pom.xml
+++ b/compiler/src/it/private-inject/pom.xml
@@ -39,6 +39,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>

--- a/compiler/src/it/provide-provider-or-lazy/pom.xml
+++ b/compiler/src/it/provide-provider-or-lazy/pom.xml
@@ -39,7 +39,11 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration><source>1.5</source><target>1.5</target></configuration>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/provides-method-with-throws-clause/pom.xml
+++ b/compiler/src/it/provides-method-with-throws-clause/pom.xml
@@ -41,7 +41,11 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration><source>1.5</source><target>1.5</target></configuration>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/same-provides-method-name/pom.xml
+++ b/compiler/src/it/same-provides-method-name/pom.xml
@@ -41,7 +41,11 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration><source>1.5</source><target>1.5</target></configuration>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/simple-missing-dependency-failure/pom.xml
+++ b/compiler/src/it/simple-missing-dependency-failure/pom.xml
@@ -42,7 +42,11 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration><source>1.5</source><target>1.5</target></configuration>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/uninjectable-supertype/pom.xml
+++ b/compiler/src/it/uninjectable-supertype/pom.xml
@@ -41,7 +41,11 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration><source>1.5</source><target>1.5</target></configuration>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/it/unused-provider-methods-fail-compilation/pom.xml
+++ b/compiler/src/it/unused-provider-methods-fail-compilation/pom.xml
@@ -41,6 +41,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>

--- a/compiler/src/it/unused-provider-methods-pass-compilation-on-library-module/pom.xml
+++ b/compiler/src/it/unused-provider-methods-pass-compilation-on-library-module/pom.xml
@@ -41,6 +41,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>


### PR DESCRIPTION
See https://plus.google.com/u/0/116467112276686980985/posts/EZMtR3D6azL

With maven-compiler-plugin 2.3.2 (the default for Maven 3.0.4 and 3.0.5), on my Linux box one IT fails because the last compiler error only has its first line printed in the Maven output, so the check in `verify.bsh` fails. On a Windows box (see original report on G+ linked above), all compiler errors have only their first line printed, so an additional test fails (but worked for me because the `verify.bsh` only looks at lines from the first few errors, not the last one).

Bumping to 3.x (tested 3.0 and 3.1) fixes the issue on my Linux box.

```
$ mvn -version
Apache Maven 3.0.5 (r01de14724cdef164cd33c7c8c2fe155faf9602da; 2013-02-19 14:51:28+0100)
Maven home: /home/tbr/bin/apache-maven-3.0.5
Java version: 1.7.0_21, vendor: Oracle Corporation
Java home: /usr/lib/jvm/java-7-openjdk-amd64/jre
Default locale: fr_FR, platform encoding: UTF-8
OS name: "linux", version: "3.8.0-19-generic", arch: "amd64", family: "unix"
```
