### PR TITLE
Rename entryPoints to injects.

### DIFF
--- a/compiler/src/it/cyclic-deps/src/main/java/test/TestApp.java
+++ b/compiler/src/it/cyclic-deps/src/main/java/test/TestApp.java
@@ -17,7 +17,6 @@
 package test;
 
 import dagger.Module;
-import dagger.ObjectGraph;
 import dagger.Provides;
 import javax.inject.Inject;
 
@@ -39,7 +38,7 @@ class TestApp {
     @Inject Foo f;
   }
 
-  @Module(entryPoints = EntryPoint.class)
+  @Module(injects = EntryPoint.class)
   static class TestModule {
     
   }
@@ -48,7 +47,7 @@ class TestApp {
   static class B { }
   static class C { }
   static class D { }
-  @Module(entryPoints = D.class)
+  @Module(injects = D.class)
   static class CyclicModule {
     @Provides A a(@SuppressWarnings("unused") D d) { return null; }
     @Provides B b(@SuppressWarnings("unused") A a) { return null; }

--- a/compiler/src/it/cyclic-deps/verify.bsh
+++ b/compiler/src/it/cyclic-deps/verify.bsh
@@ -3,7 +3,7 @@ import java.io.File;
 
 File buildLog = new File(basedir, "build.log");
 new BuildLogValidator().assertHasText(buildLog, new String[]{
-    "TestApp.java:[43", "Graph validation", "Dependency cycle"});
+    "TestApp.java:[42", "Graph validation", "Dependency cycle"});
 new BuildLogValidator().assertHasText(buildLog, new String[]{
-    "TestApp.java:[52", "Graph validation", "Dependency cycle"});
+    "TestApp.java:[51", "Graph validation", "Dependency cycle"});
     

--- a/compiler/src/it/default-package-injected-type/src/main/java/TestApp.java
+++ b/compiler/src/it/default-package-injected-type/src/main/java/TestApp.java
@@ -31,7 +31,7 @@ class TestApp implements Runnable {
     ObjectGraph.create(new TestModule()).get(TestApp.class).run();
   }
   
-  @Module(entryPoints = { TestApp.class })
+  @Module(injects = { TestApp.class })
   static class TestModule {}
 
   @Singleton

--- a/compiler/src/it/extension-graph/src/main/java/test/TestApp.java
+++ b/compiler/src/it/extension-graph/src/main/java/test/TestApp.java
@@ -34,10 +34,10 @@ class TestApp implements Runnable {
     extension.get(TestApp.class).run();
   }
   
-  @Module(entryPoints = { A.class, B.class })
+  @Module(injects = { A.class, B.class })
   static class RootModule { }
 
-  @Module(addsTo=RootModule.class, entryPoints = { C.class, TestApp.class })
+  @Module(addsTo=RootModule.class, injects = { C.class, TestApp.class })
   static class ExtensionModule { }
 
   @Singleton

--- a/compiler/src/it/include-non-module/src/main/java/test/TestApp.java
+++ b/compiler/src/it/include-non-module/src/main/java/test/TestApp.java
@@ -29,7 +29,7 @@ class TestApp {
   @Inject String s;
 
   @Module(
-      entryPoints = TestApp.class,
+      injects = TestApp.class,
       includes = TestApp.class)
   static class TestModule {
     @Provides String provideString() {

--- a/compiler/src/it/inject-parameterized-type/src/main/java/test/TestApp.java
+++ b/compiler/src/it/inject-parameterized-type/src/main/java/test/TestApp.java
@@ -32,7 +32,7 @@ class TestApp {
   static class Subtype extends Supertype<Integer> {
   }
 
-  @Module(entryPoints = Subtype.class)
+  @Module(injects = Subtype.class)
   static class TestModule {
     @Provides String provideString() {
       return "a";

--- a/compiler/src/it/missing-at-inject-constructor/src/main/java/test/TestApp.java
+++ b/compiler/src/it/missing-at-inject-constructor/src/main/java/test/TestApp.java
@@ -37,7 +37,7 @@ class TestApp implements Runnable {
     public void doit() { throw AssertionError(); };
   }
   
-  @Module(entryPoints = TestApp.class)
+  @Module(injects = TestApp.class)
   static class TestModule {
     /* missing */ // @Provides Dependency a() { return new Dependency(); }
   }

--- a/compiler/src/it/multiple-provides-methods/src/main/java/test/TestApp.java
+++ b/compiler/src/it/multiple-provides-methods/src/main/java/test/TestApp.java
@@ -29,7 +29,7 @@ class TestApp {
     @Inject Integer integer;
   }
 
-  @Module(entryPoints = InjectableSubclass.class)
+  @Module(injects = InjectableSubclass.class)
   static class TestModule {
     @Provides String string() {
       return "string";

--- a/compiler/src/it/provides-method-with-throws-clause/src/main/java/test/TestApp.java
+++ b/compiler/src/it/provides-method-with-throws-clause/src/main/java/test/TestApp.java
@@ -37,7 +37,7 @@ class TestApp implements Runnable {
     ObjectGraph.create(new TestModule()).get(TestApp.class).run();
   }
 
-  @Module(entryPoints = TestApp.class)
+  @Module(injects = TestApp.class)
   static class TestModule {
 
     @Provides String string() throws IOException {

--- a/compiler/src/it/same-provides-method-name/src/main/java/test/TestApp.java
+++ b/compiler/src/it/same-provides-method-name/src/main/java/test/TestApp.java
@@ -42,7 +42,7 @@ class TestApp implements Runnable {
   static class MyFoo extends Foo {
   }
 
-  @Module(entryPoints = TestApp.class)
+  @Module(injects = TestApp.class)
   static class TestModule {
 
     @Provides Foo providesFoo(MyFoo foo) {

--- a/compiler/src/it/simple-missing-dependency-failure/src/main/java/test/TestApp.java
+++ b/compiler/src/it/simple-missing-dependency-failure/src/main/java/test/TestApp.java
@@ -36,7 +36,7 @@ class TestApp implements Runnable {
     void doit();
   }
   
-  @Module(entryPoints = TestApp.class)
+  @Module(injects = TestApp.class)
   static class TestModule {
     /* missing */ // @Provides Dependency a() { return new Dependency(); }
   }

--- a/compiler/src/it/uninjectable-supertype/src/main/java/test/TestApp.java
+++ b/compiler/src/it/uninjectable-supertype/src/main/java/test/TestApp.java
@@ -27,7 +27,7 @@ class TestApp {
     @Inject String string;
   }
 
-  @Module(entryPoints = InjectableSubclass.class)
+  @Module(injects = InjectableSubclass.class)
   static class TestModule {
     @Provides String provideString() {
       return "string";

--- a/compiler/src/main/java/dagger/internal/codegen/FullGraphProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/FullGraphProcessor.java
@@ -148,9 +148,9 @@ public final class FullGraphProcessor extends AbstractProcessor {
         boolean library = (Boolean) annotation.get("library");
         Map<String, Binding<?>> addTo = overrides ? overrideBindings : baseBindings;
 
-        // Gather the entry points from the annotation.
-        for (Object entryPoint : (Object[]) annotation.get("entryPoints")) {
-          linker.requestBinding(GeneratorKeys.rawMembersKey((TypeMirror) entryPoint),
+        // Gather the injectable types from the annotation.
+        for (Object injectableType : (Object[]) annotation.get("injects")) {
+          linker.requestBinding(GeneratorKeys.rawMembersKey((TypeMirror) injectableType),
               module.getQualifiedName().toString(), false, true);
         }
 

--- a/compiler/src/main/java/dagger/internal/codegen/ProvidesProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/ProvidesProcessor.java
@@ -174,7 +174,7 @@ public final class ProvidesProcessor extends AbstractProcessor {
 
     TypeMirror objectType = elementUtils.getTypeElement("java.lang.Object").asType();
 
-    // Catch any stray modules without @Provides since their entry points
+    // Catch any stray modules without @Provides since their injectable types
     // should still be registered and a ModuleAdapter should still be written.
     for (Element module : env.getElementsAnnotatedWith(Module.class)) {
       if (!module.getKind().equals(ElementKind.CLASS)) {
@@ -214,7 +214,7 @@ public final class ProvidesProcessor extends AbstractProcessor {
     }
 
     Object[] staticInjections = (Object[]) module.get("staticInjections");
-    Object[] entryPoints = (Object[]) module.get("entryPoints");
+    Object[] injects = (Object[]) module.get("injects");
     Object[] includes = (Object[]) module.get("includes");
 
     boolean overrides = (Boolean) module.get("overrides");
@@ -241,15 +241,15 @@ public final class ProvidesProcessor extends AbstractProcessor {
     writer.beginType(adapterName, "class", PUBLIC | FINAL,
         JavaWriter.type(ModuleAdapter.class, typeName));
 
-    StringBuilder entryPointsField = new StringBuilder().append("{ ");
-    for (Object entryPoint : entryPoints) {
-      TypeMirror typeMirror = (TypeMirror) entryPoint;
+    StringBuilder injectsField = new StringBuilder().append("{ ");
+    for (Object injectableType : injects) {
+      TypeMirror typeMirror = (TypeMirror) injectableType;
       String key = GeneratorKeys.rawMembersKey(typeMirror);
-      entryPointsField.append(JavaWriter.stringLiteral(key)).append(", ");
+      injectsField.append(JavaWriter.stringLiteral(key)).append(", ");
     }
-    entryPointsField.append("}");
-    writer.emitField("String[]", "ENTRY_POINTS", PRIVATE | STATIC | FINAL,
-        entryPointsField.toString());
+    injectsField.append("}");
+    writer.emitField("String[]", "INJECTS", PRIVATE | STATIC | FINAL,
+        injectsField.toString());
 
     StringBuilder staticInjectionsField = new StringBuilder().append("{ ");
     for (Object staticInjection : staticInjections) {
@@ -276,7 +276,7 @@ public final class ProvidesProcessor extends AbstractProcessor {
 
     writer.emitEmptyLine();
     writer.beginMethod(null, adapterName, PUBLIC);
-    writer.emitStatement("super(ENTRY_POINTS, STATIC_INJECTIONS, %s /*overrides*/, "
+    writer.emitStatement("super(INJECTS, STATIC_INJECTIONS, %s /*overrides*/, "
         + "INCLUDES, %s /*complete*/, %s /*library*/)", overrides, complete, library);
     writer.endMethod();
 

--- a/core/src/main/java/dagger/Module.java
+++ b/core/src/main/java/dagger/Module.java
@@ -26,7 +26,29 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface Module {
-  Class<?>[] entryPoints() default { };
+  /**
+   * Returns classes that object graphs created with this module must be able to
+   * inject. This includes both classes passed to {@link ObjectGraph#get} and
+   * the types of instances passed {@link ObjectGraph#inject}.
+   *
+   * <p>It is an error to call {@link ObjectGraph#get} or {@link
+   * ObjectGraph#inject} with a type that isn't listed in the {@code injects}
+   * set for any of the object graph's modules. Making such a call will trigger
+   * an {@code IllegalArgumentException} at runtime.
+   *
+   * <p>Maintaining this set is onerous, but doing so provides benefits to the
+   * application. This set enables dagger to perform more aggressive static
+   * analysis than would be otherwise possible:
+   * <ul>
+   *   <li><strong>Detect missing bindings.</strong> Dagger can check that all
+   *       injected dependencies can be satisfied. Set {@code complete=false} to
+   *       disable this check for the current module.
+   *   <li><strong>Detect unused bindings.</strong> Dagger can check that all
+   *       provides methods are used to satisfy injected dependencies. Set
+   *       {@code library=true} to disable this check for the current module.
+   * </ul>
+   */
+  Class<?>[] injects() default { };
   Class<?>[] staticInjections() default { };
 
   /**
@@ -62,12 +84,12 @@ public @interface Module {
 
   /**
    * False if all the included bindings in this module are necessary to satisfy
-   * all of its entry points. If a module is not a library module, it is eligible
-   * for additional static checking: tools can detect if included bindings are not
-   * necessary. If you provide bindings that are not used by this module's graph,
-   * then you must declare {@code library = true}.
-   * <p>
-   * This is intended to help you detect dead code.
+   * all of its {@link #injects injectable types}. If a module is not a library
+   * module, it is eligible for additional static checking: tools can detect if
+   * included bindings are not necessary. If you provide bindings that are not
+   * used by this module's graph, then you must declare {@code library = true}.
+   *
+   * <p>This is intended to help you detect dead code.
    */
   boolean library() default false;
 }

--- a/core/src/main/java/dagger/internal/Linker.java
+++ b/core/src/main/java/dagger/internal/Linker.java
@@ -204,9 +204,9 @@ public final class Linker {
    * enqueued to be linked.
    *
    * @param mustBeInjectable true if the the referenced key doesn't need to be
-   *     injectable. This is necessary for entry points (so that framework code
-   *     can inject arbitrary entry points like JUnit test cases or Android
-   *     activities) and for supertypes.
+   *     injectable. This is necessary for injectable types (so that framework
+   *     code can inject arbitrary classes like JUnit test cases or Android
+   *     activities) and also for supertypes.
    */
   public Binding<?> requestBinding(String key, Object requiredBy, boolean mustBeInjectable,
       boolean library) {

--- a/core/src/main/java/dagger/internal/ModuleAdapter.java
+++ b/core/src/main/java/dagger/internal/ModuleAdapter.java
@@ -23,7 +23,7 @@ import java.util.Map;
  * Extracts bindings from an {@code @Module}-annotated class.
  */
 public abstract class ModuleAdapter<T> {
-  public final String[] entryPoints;
+  public final String[] injectableTypes;
   public final Class<?>[] staticInjections;
   public final boolean overrides;
   public final Class<?>[] includes;
@@ -31,9 +31,9 @@ public abstract class ModuleAdapter<T> {
   public final boolean library;
   protected T module;
 
-  protected ModuleAdapter(String[] entryPoints, Class<?>[] staticInjections, boolean overrides,
+  protected ModuleAdapter(String[] injectableTypes, Class<?>[] staticInjections, boolean overrides,
       Class<?>[] includes, boolean complete, boolean library) {
-    this.entryPoints = entryPoints;
+    this.injectableTypes = injectableTypes;
     this.staticInjections = staticInjections;
     this.overrides = overrides;
     this.includes = includes;

--- a/core/src/main/java/dagger/internal/plugins/reflect/ReflectiveModuleAdapter.java
+++ b/core/src/main/java/dagger/internal/plugins/reflect/ReflectiveModuleAdapter.java
@@ -39,7 +39,7 @@ final class ReflectiveModuleAdapter extends ModuleAdapter<Object> {
 
   public ReflectiveModuleAdapter(Class<?> moduleClass, Module annotation) {
     super(
-        toMemberKeys(annotation.entryPoints()),
+        toMemberKeys(annotation.injects()),
         annotation.staticInjections(),
         annotation.overrides(),
         annotation.includes(),
@@ -48,10 +48,10 @@ final class ReflectiveModuleAdapter extends ModuleAdapter<Object> {
     this.moduleClass = moduleClass;
   }
 
-  private static String[] toMemberKeys(Class<?>[] entryPoints) {
-    String[] result = new String[entryPoints.length];
-    for (int i = 0; i < entryPoints.length; i++) {
-      result[i] = Keys.getMembersKey(entryPoints[i]);
+  private static String[] toMemberKeys(Class<?>[] injectableTypes) {
+    String[] result = new String[injectableTypes.length];
+    for (int i = 0; i < injectableTypes.length; i++) {
+      result[i] = Keys.getMembersKey(injectableTypes[i]);
     }
     return result;
   }

--- a/core/src/test/java/dagger/ExtensionTest.java
+++ b/core/src/test/java/dagger/ExtensionTest.java
@@ -49,9 +49,9 @@ public final class ExtensionTest {
     @Inject C c;
   }
 
-  @Module(entryPoints = { A.class, B.class }) static class RootModule { }
+  @Module(injects = { A.class, B.class }) static class RootModule { }
 
-  @Module(addsTo = RootModule.class, entryPoints = { C.class, D.class })
+  @Module(addsTo = RootModule.class, injects = { C.class, D.class })
   static class ExtensionModule { }
 
   @Test public void basicExtension() {
@@ -63,8 +63,8 @@ public final class ExtensionTest {
     assertThat(root.get(A.class)).isNotNull();
     assertThat(root.get(A.class)).isSameAs(root.get(A.class)); // Present and Singleton.
     assertThat(root.get(B.class)).isNotSameAs(root.get(B.class)); // Not singleton.
-    assertFailNoEntryPoint(root, C.class); // Not declared in RootModule.
-    assertFailNoEntryPoint(root, D.class); // Not declared in RootModule.
+    assertFailInjectNotRegistered(root, C.class); // Not declared in RootModule.
+    assertFailInjectNotRegistered(root, D.class); // Not declared in RootModule.
 
     // Extension graph behaves as the root graph would for root-ish things.
     ObjectGraph extension = root.plus(new ExtensionModule());
@@ -81,8 +81,8 @@ public final class ExtensionTest {
     assertThat(app.get(A.class)).isNotNull();
     assertThat(app.get(A.class)).isSameAs(app.get(A.class));
     assertThat(app.get(B.class)).isNotSameAs(app.get(B.class));
-    assertFailNoEntryPoint(app, C.class);
-    assertFailNoEntryPoint(app, D.class);
+    assertFailInjectNotRegistered(app, C.class);
+    assertFailInjectNotRegistered(app, D.class);
 
     ObjectGraph request1 = app.plus(new ExtensionModule());
     ObjectGraph request2 = app.plus(new ExtensionModule());
@@ -101,11 +101,11 @@ public final class ExtensionTest {
     assertThat(request1.get(C.class).a).isSameAs(request2.get(C.class).a);
   }
 
-  private void assertFailNoEntryPoint(ObjectGraph graph, Class<?> clazz) {
+  private void assertFailInjectNotRegistered(ObjectGraph graph, Class<?> clazz) {
     try {
       assertThat(graph.get(clazz)).isNull();
     } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage()).contains("No entry point");
+      assertThat(e.getMessage()).contains("No inject");
     }
   }
 }

--- a/core/src/test/java/dagger/ExtensionWithStateTest.java
+++ b/core/src/test/java/dagger/ExtensionWithStateTest.java
@@ -32,7 +32,7 @@ public final class ExtensionWithStateTest {
   }
 
   @Module(
-      entryPoints = A.class, // for testing
+      injects = A.class, // for testing
       complete = false
   )
   static class RootModule {
@@ -43,7 +43,7 @@ public final class ExtensionWithStateTest {
     @Provides A provideA() { return a; }
   }
 
-  @Module(addsTo = RootModule.class, entryPoints = { B.class })
+  @Module(addsTo = RootModule.class, injects = { B.class })
   static class ExtensionModule { }
 
   @Test public void basicInjectionWithExtension() {

--- a/core/src/test/java/dagger/InjectStaticsTest.java
+++ b/core/src/test/java/dagger/InjectStaticsTest.java
@@ -56,7 +56,7 @@ public final class InjectStaticsTest {
   @Test public void instanceFieldsNotInjectedByInjectStatics() {
     @Module(
         staticInjections = InjectsStaticAndNonStatic.class,
-        entryPoints = InjectsStaticAndNonStatic.class)
+        injects = InjectsStaticAndNonStatic.class)
     class TestModule {
       @Provides String provideString() {
         return "static";
@@ -75,7 +75,7 @@ public final class InjectStaticsTest {
   @Test public void staticFieldsNotInjectedByInjectMembers() {
     @Module(
         staticInjections = InjectsStaticAndNonStatic.class,
-        entryPoints = InjectsStaticAndNonStatic.class)
+        injects = InjectsStaticAndNonStatic.class)
     class TestModule {
       @Provides String provideString() {
         throw new AssertionError();

--- a/core/src/test/java/dagger/InjectionOfLazyTest.java
+++ b/core/src/test/java/dagger/InjectionOfLazyTest.java
@@ -38,7 +38,7 @@ public final class InjectionOfLazyTest {
       @Inject Lazy<Integer> j;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides Integer provideInteger() {
         return counter.incrementAndGet();
@@ -59,7 +59,7 @@ public final class InjectionOfLazyTest {
     class TestEntryPoint {
       @Inject Lazy<String> i;
     }
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides String provideInteger() {
         provideCounter.incrementAndGet();
@@ -81,7 +81,7 @@ public final class InjectionOfLazyTest {
       @Inject Provider<Lazy<Integer>> providerOfLazyInteger;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides Integer provideInteger() {
         return counter.incrementAndGet();
@@ -107,7 +107,7 @@ public final class InjectionOfLazyTest {
       @Inject Lazy<Integer> lazyInteger;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides Integer provideInteger() {
         return counter.incrementAndGet();

--- a/core/src/test/java/dagger/InjectionTest.java
+++ b/core/src/test/java/dagger/InjectionTest.java
@@ -41,7 +41,7 @@ public final class InjectionTest {
       @Inject Provider<G> gProvider;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides E provideE(F f) {
         return new E(f);
@@ -106,7 +106,7 @@ public final class InjectionTest {
       @Inject Provider<A> aProvider;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
     }
 
@@ -125,7 +125,7 @@ public final class InjectionTest {
       @Inject Provider<I> iProvider;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides @Singleton F provideF() {
         return new F();
@@ -153,7 +153,7 @@ public final class InjectionTest {
       @Inject @Named("two") A aTwo;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides @Named("one") A getOne() {
         return one;
@@ -175,7 +175,7 @@ public final class InjectionTest {
       @Inject Provider<L> lProvider;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       A a1;
       A a2;
@@ -212,7 +212,7 @@ public final class InjectionTest {
       @Inject F f2;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides @Singleton F provideF() {
         return new F();
@@ -242,7 +242,7 @@ public final class InjectionTest {
       @Inject @Named("a") A a;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
     }
 
@@ -259,7 +259,7 @@ public final class InjectionTest {
       @Inject Q q;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides F provideF() {
         return new F();
@@ -276,7 +276,7 @@ public final class InjectionTest {
       @Inject T t;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
     }
 
@@ -305,7 +305,7 @@ public final class InjectionTest {
       @Inject Provider<A> aProvider;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       boolean sInjected = false;
 
@@ -377,7 +377,7 @@ public final class InjectionTest {
       @Inject Provider<A> aProvider;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides @Singleton A provideA() {
         return new A();
@@ -394,7 +394,7 @@ public final class InjectionTest {
       @Inject Provider<E> eProvider;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class BaseModule {
       @Provides F provideF() {
         throw new AssertionError();
@@ -423,7 +423,7 @@ public final class InjectionTest {
       @Inject RandomAccess randomAccess;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
     }
 
@@ -440,7 +440,7 @@ public final class InjectionTest {
       @Inject AbstractList<?> abstractList;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
     }
 
@@ -471,7 +471,7 @@ public final class InjectionTest {
       @Inject ExtendsParameterizedType extendsParameterizedType;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides String provideString() {
         return "injected";
@@ -488,7 +488,7 @@ public final class InjectionTest {
       @Inject List<String> listOfStrings;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides List<String> provideList() {
         return Arrays.asList("a", "b");
@@ -505,7 +505,7 @@ public final class InjectionTest {
       @Inject List<? extends Number> listOfNumbers;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides List<? extends Number> provideList() {
         return Arrays.asList(1, 2);
@@ -529,7 +529,7 @@ public final class InjectionTest {
       @Inject Parameterized<Long> parameterized;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides String provideString() {
         return "injected";
@@ -555,7 +555,7 @@ public final class InjectionTest {
   @Test public void getInstance() {
     final AtomicInteger next = new AtomicInteger(0);
 
-    @Module(entryPoints = Integer.class)
+    @Module(injects = Integer.class)
     class TestModule {
       @Provides Integer provideInteger() {
         return next.getAndIncrement();
@@ -584,7 +584,7 @@ public final class InjectionTest {
   }
 
   @Test public void getInstanceOfPrimitive() {
-    @Module(entryPoints = int.class)
+    @Module(injects = int.class)
     class TestModule {
       @Provides int provideInt() {
         return 1;
@@ -596,7 +596,7 @@ public final class InjectionTest {
   }
 
   @Test public void getInstanceOfArray() {
-    @Module(entryPoints = int[].class)
+    @Module(injects = int[].class)
     class TestModule {
       @Provides int[] provideIntArray() {
         return new int[] { 1, 2, 3 };
@@ -612,7 +612,7 @@ public final class InjectionTest {
       @Inject String s;
     }
 
-    @Module(entryPoints = BoundTwoWays.class)
+    @Module(injects = BoundTwoWays.class)
     class TestModule {
       @Provides
       BoundTwoWays provideBoundTwoWays() {
@@ -641,7 +641,7 @@ public final class InjectionTest {
   }
 
   @Test public void entryPointNeedsNoInjectAnnotation() {
-    @Module(entryPoints = NoInjections.class)
+    @Module(injects = NoInjections.class)
     class TestModule {
     }
 
@@ -655,7 +655,7 @@ public final class InjectionTest {
   }
 
   @Test public void cannotGetOnMembersOnlyInjectionPoint() {
-    @Module(entryPoints = InjectMembersOnly.class)
+    @Module(injects = InjectMembersOnly.class)
     class TestModule {
       @Provides String provideString() {
         return "injected";
@@ -698,7 +698,7 @@ public final class InjectionTest {
   }
 
   @Test public void twoAtInjectConstructorsIsRejected() {
-    @Module(entryPoints = TwoAtInjectConstructors.class)
+    @Module(injects = TwoAtInjectConstructors.class)
     class TestModule {
       @Provides String provideString() {
         throw new AssertionError();
@@ -718,7 +718,7 @@ public final class InjectionTest {
       @Inject String string;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides String provideString() {
         throw new ClassCastException("foo");
@@ -740,7 +740,7 @@ public final class InjectionTest {
   }
 
   @Test public void runtimeConstructorExceptionsAreNotWrapped() {
-    @Module(entryPoints = ThrowsOnConstruction.class)
+    @Module(injects = ThrowsOnConstruction.class)
     class TestModule {
     }
 
@@ -756,10 +756,10 @@ public final class InjectionTest {
     @Inject C c; // Singleton.
   }
 
-  @Module(complete=false, entryPoints=C.class)
+  @Module(complete=false, injects =C.class)
   static class RootModule { }
 
-  @Module(addsTo=RootModule.class, entryPoints=SingletonLinkedFromExtension.class)
+  @Module(addsTo=RootModule.class, injects =SingletonLinkedFromExtension.class)
   static class ExtensionModule { }
 
   @Test public void testSingletonLinkingThroughExtensionGraph() {
@@ -774,7 +774,7 @@ public final class InjectionTest {
       @Inject private Object nope;
     }
 
-    @Module(entryPoints = Test.class)
+    @Module(injects = Test.class)
     class TestModule {
       @Provides Object provideObject() {
         return null;
@@ -795,7 +795,7 @@ public final class InjectionTest {
       }
     }
 
-    @Module(entryPoints = Test.class)
+    @Module(injects = Test.class)
     class TestModule {
     }
 

--- a/core/src/test/java/dagger/LazyInjectionTest.java
+++ b/core/src/test/java/dagger/LazyInjectionTest.java
@@ -24,8 +24,8 @@ import static org.fest.assertions.Assertions.assertThat;
 
 @RunWith(JUnit4.class)
 public final class LazyInjectionTest {
-  @Test public void getLazyDoesNotCauseEntryPointsToBeLoaded() {
-    @Module(entryPoints = LazyEntryPoint.class)
+  @Test public void getLazyDoesNotCauseInjectedTypesToBeLoaded() {
+    @Module(injects = LazyEntryPoint.class)
     class TestModule {
     }
 
@@ -99,7 +99,7 @@ public final class LazyInjectionTest {
       @Inject String injected;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides String provideString(Integer integer) {
         return integer.toString();

--- a/core/src/test/java/dagger/MembersInjectorTest.java
+++ b/core/src/test/java/dagger/MembersInjectorTest.java
@@ -36,7 +36,7 @@ public final class MembersInjectorTest {
       @Inject MembersInjector<Injectable> membersInjector;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class StringModule {
       @Provides String provideString() {
         return "injected";
@@ -67,7 +67,7 @@ public final class MembersInjectorTest {
       @Inject MembersInjector<Unconstructable> membersInjector;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class StringModule {
       @Provides String provideString() {
         return "injected";
@@ -88,7 +88,7 @@ public final class MembersInjectorTest {
       @Inject Unconstructable unconstructable;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
     }
 
@@ -105,7 +105,7 @@ public final class MembersInjectorTest {
       @Inject Provider<Unconstructable> provider;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
     }
 
@@ -122,7 +122,7 @@ public final class MembersInjectorTest {
       @Inject MembersInjector<UnconstructableSingleton> membersInjector;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
     }
 
@@ -152,7 +152,7 @@ public final class MembersInjectorTest {
       @Inject MembersInjector<NonStaticInner> membersInjector;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides String provideString() {
         return "injected";
@@ -171,7 +171,7 @@ public final class MembersInjectorTest {
       @Inject NonStaticInner nonStaticInner;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
     }
 
@@ -193,7 +193,7 @@ public final class MembersInjectorTest {
       @Inject MembersInjector<InjectsString> membersInjector;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides InjectsString provideInjectsString() {
         InjectsString result = new InjectsString();

--- a/core/src/test/java/dagger/ModuleTest.java
+++ b/core/src/test/java/dagger/ModuleTest.java
@@ -30,7 +30,7 @@ public final class ModuleTest {
     @Inject String s;
   }
 
-  @Module(entryPoints = TestEntryPoint.class)
+  @Module(injects = TestEntryPoint.class)
   static class ModuleWithEntryPoint {
   }
 
@@ -79,7 +79,7 @@ public final class ModuleTest {
   @Test public void childModuleWithBinding() {
 
     @Module(
-        entryPoints = TestEntryPoint.class,
+        injects = TestEntryPoint.class,
         includes = ModuleWithBinding.class
     )
     class TestModule {
@@ -98,7 +98,7 @@ public final class ModuleTest {
   @Test public void childModuleWithChildModule() {
 
     @Module(
-        entryPoints = TestEntryPoint.class,
+        injects = TestEntryPoint.class,
         includes = ModuleWithChildModule.class
     )
     class TestModule {
@@ -138,7 +138,7 @@ public final class ModuleTest {
   @Test public void childModuleWithManualConstruction() {
 
     @Module(
-        entryPoints = TestEntryPoint.class,
+        injects = TestEntryPoint.class,
         includes = ModuleWithConstructor.class
     )
     class TestModule {
@@ -154,11 +154,11 @@ public final class ModuleTest {
 
   static class B { @Inject A a; }
 
-  @Module(entryPoints = A.class) public static class TestModuleA {
+  @Module(injects = A.class) public static class TestModuleA {
     @Provides A a() { return new A(); }
   }
 
-  @Module(includes = TestModuleA.class, entryPoints = B.class) public static class TestModuleB {}
+  @Module(includes = TestModuleA.class, injects = B.class) public static class TestModuleB {}
 
   @Test public void autoInstantiationOfModules() {
     // Have to make these non-method-scoped or instantiation errors occur.

--- a/core/src/test/java/dagger/ProblemDetectorTest.java
+++ b/core/src/test/java/dagger/ProblemDetectorTest.java
@@ -29,7 +29,7 @@ public final class ProblemDetectorTest {
       @Inject Rock rock;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
     }
 

--- a/core/src/test/java/dagger/SetBindingTest.java
+++ b/core/src/test/java/dagger/SetBindingTest.java
@@ -43,7 +43,7 @@ public final class SetBindingTest {
       @Inject Set<String> strings;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides(type=SET) String provideFirstString() { return "string1"; }
       @Provides(type=SET) String provideSecondString() { return "string2"; }
@@ -63,7 +63,7 @@ public final class SetBindingTest {
       @Provides(type=SET) String provideSecondString() { return "string2"; }
     }
 
-    @Module(entryPoints = TestEntryPoint.class, includes = TestIncludesModule.class)
+    @Module(injects = TestEntryPoint.class, includes = TestIncludesModule.class)
     class TestModule {
       @Provides(type=SET) String provideFirstString() { return "string1"; }
     }
@@ -81,7 +81,7 @@ public final class SetBindingTest {
       @Inject Set<Integer> objects2;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides(type=SET) @Singleton Integer a() { return singletonCounter.getAndIncrement(); }
       @Provides(type=SET) Integer b() { return defaultCounter.getAndIncrement(); }
@@ -92,7 +92,7 @@ public final class SetBindingTest {
     assertEquals(set(100, 201), ep.objects2);
   }
 
-  @Test public void multiValueBindings_WithSingletonsAcrossMultipleEntryPoints() {
+  @Test public void multiValueBindings_WithSingletonsAcrossMultipleInjectableTypes() {
     final AtomicInteger singletonCounter = new AtomicInteger(100);
     final AtomicInteger defaultCounter = new AtomicInteger(200);
     class TestEntryPoint1 {
@@ -102,7 +102,7 @@ public final class SetBindingTest {
       @Inject Set<Integer> objects2;
     }
 
-    @Module(entryPoints = { TestEntryPoint1.class, TestEntryPoint2.class })
+    @Module(injects = { TestEntryPoint1.class, TestEntryPoint2.class })
     class TestModule {
       @Provides(type=SET) @Singleton Integer a() { return singletonCounter.getAndIncrement(); }
       @Provides(type=SET) Integer b() { return defaultCounter.getAndIncrement(); }
@@ -122,7 +122,7 @@ public final class SetBindingTest {
       @Inject @Named("foo") Set<String> fooStrings;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides(type=SET) String provideString1() { return "string1"; }
       @Provides(type=SET) String provideString2() { return "string2"; }
@@ -158,7 +158,7 @@ public final class SetBindingTest {
         };
       }
     }
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides(type=SET) LogSink nullLogger() {
         return new LogSink() { @Override public void log(LogMessage message) {} };
@@ -178,7 +178,7 @@ public final class SetBindingTest {
       @Inject Set<String> strings;
     }
 
-    @Module(entryPoints = TestEntryPoint.class)
+    @Module(injects = TestEntryPoint.class)
     class TestModule {
       @Provides(type=SET) String provideString1() { return "string1"; }
       @Provides(type=SET) String provideString2() { return "string2"; }

--- a/core/src/test/java/dagger/ThreadSafetyTest.java
+++ b/core/src/test/java/dagger/ThreadSafetyTest.java
@@ -49,7 +49,7 @@ public final class ThreadSafetyTest {
     @Inject Lazy<Integer> lazy;
   }
 
-  @Module(entryPoints = { Long.class, LazyEntryPoint.class })
+  @Module(injects = { Long.class, LazyEntryPoint.class })
   static class LatchingModule {
     private final AtomicInteger count = new AtomicInteger(FIRST_VALUE);
     private final CountDownLatch latch;

--- a/core/src/test/java/dagger/UnusedProviderTest.java
+++ b/core/src/test/java/dagger/UnusedProviderTest.java
@@ -26,7 +26,7 @@ public class UnusedProviderTest {
     }
     class BagOfMoney {
     }
-    @Module(entryPoints = EntryPoint.class, library = true) class TestModule {
+    @Module(injects = EntryPoint.class, library = true) class TestModule {
       @Provides BagOfMoney providesMoney() {
         return new BagOfMoney();
       }
@@ -42,7 +42,7 @@ public class UnusedProviderTest {
     class BagOfMoney {
     }
 
-    @Module(entryPoints = EntryPoint.class) class TestModule {
+    @Module(injects = EntryPoint.class) class TestModule {
       @Provides BagOfMoney providesMoney() {
         return new BagOfMoney();
       }
@@ -63,13 +63,13 @@ public class UnusedProviderTest {
     class BagOfMoney {
     }
 
-    @Module(entryPoints = EntryPoint.class, library = true) class ExampleLibraryModule {
+    @Module(injects = EntryPoint.class, library = true) class ExampleLibraryModule {
       @Provides BagOfMoney providesMoney() {
         return new BagOfMoney();
       }
     }
 
-    @Module(entryPoints = EntryPoint.class) class TestModule {
+    @Module(injects = EntryPoint.class) class TestModule {
     }
 
     ObjectGraph graph = ObjectGraph.create(new TestModule());

--- a/examples/simple/src/main/java/coffee/DripCoffeeModule.java
+++ b/examples/simple/src/main/java/coffee/DripCoffeeModule.java
@@ -5,7 +5,7 @@ import dagger.Provides;
 import javax.inject.Singleton;
 
 @Module(
-    entryPoints = CoffeeApp.class,
+    injects = CoffeeApp.class,
     includes = PumpModule.class
 )
 class DripCoffeeModule {

--- a/website/index.html
+++ b/website/index.html
@@ -108,7 +108,7 @@ class DripCoffeeModule {
 ObjectGraph objectGraph = ObjectGraph.create(new DripCoffeeModule());
 </pre>
 
-<p>In order to put the graph to use we need to create an <strong>entry point</strong>. This is usually the main class that starts the application. In this example, the <code>CoffeeApp</code> class serves as the entry point. We ask the graph to provide an injected instance of this type:</p>
+<p>In order to put the graph to use we need to <strong>bootstrap injection</strong>. This usually requires injecting the main class of a command line app, or the activity classes of an Android app. In our coffee example, the <code>CoffeeApp</code> class is used to start dependency injection. We ask the graph to provide an injected instance of the class:</p>
 
 <pre class="prettyprint">
 class CoffeeApp implements Runnable {
@@ -126,20 +126,20 @@ class CoffeeApp implements Runnable {
 }
 </pre>
 
-<p>The only thing that's missing is that the entry point class <code>CoffeeApp</code> isn't included in the graph. We need to explicitly register it as an entry point in the <code>@Module</code> annotation.</p>
+<p>The only thing that's missing is that the injectable class <code>CoffeeApp</code> isn't known by the graph. We need to explicitly register it as an injected type in the <code>@Module</code> annotation.</p>
 
 <pre class="prettyprint">
 @Module(
-    entryPoints = CoffeeApp.class
+    injects = { CoffeeApp.class }
 )
 class DripCoffeeModule {
   ...
 }
 </pre>
 
-<p>Entry points enable the complete graph to be validated <strong>at compile time</strong>. Detecting problems early speeds up development and takes some of the danger out of refactoring.</p>
+<p>The <code>injects</code> option enables the complete graph to be validated <strong>at compile time</strong>. Detecting problems early speeds up development and takes some of the danger out of refactoring.</p>
 
-<p>Now that the graph is constructed and the entry point is injected, we run our coffee maker app. Fun.</p>
+<p>Now that the graph is constructed and the root object is injected, we run our coffee maker app. Fun.</p>
 
 <pre>
 $ java -cp ... coffee.CoffeeApp
@@ -335,7 +335,7 @@ public class CoffeeMakerTest {
 
   @Module(
       includes = DripCoffeeModule.class,
-      entryPoints = CoffeeMakerTest.class,
+      injects = CoffeeMakerTest.class,
       overrides = true
   )
   static class TestModule {


### PR DESCRIPTION
This is closer to what we actually do. It's a type that can be
injected. There's a slight bit of ambiguity because we use 'inject'
to describe types that are included implicitly. I don't anticipate
this to be a problem in practice.
