### PR TITLE
Fix validation when passing an interface to the injects list.

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/CodeGen.java
+++ b/compiler/src/main/java/dagger/internal/codegen/CodeGen.java
@@ -296,4 +296,9 @@ final class CodeGen {
     return ((TypeElement) method.getEnclosingElement()).getQualifiedName()
         + "." + method.getSimpleName() + "()";
   }
+
+  public static boolean isInterface(TypeMirror typeMirror) {
+    return typeMirror instanceof DeclaredType
+        && ((DeclaredType) typeMirror).asElement().getKind() == ElementKind.INTERFACE;
+  }
 }

--- a/compiler/src/main/java/dagger/internal/codegen/FullGraphProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/FullGraphProcessor.java
@@ -149,9 +149,12 @@ public final class FullGraphProcessor extends AbstractProcessor {
         Map<String, Binding<?>> addTo = overrides ? overrideBindings : baseBindings;
 
         // Gather the injectable types from the annotation.
-        for (Object injectableType : (Object[]) annotation.get("injects")) {
-          linker.requestBinding(GeneratorKeys.rawMembersKey((TypeMirror) injectableType),
-              module.getQualifiedName().toString(), false, true);
+        for (Object injectableTypeObject : (Object[]) annotation.get("injects")) {
+          TypeMirror injectableType = (TypeMirror) injectableTypeObject;
+          String key = CodeGen.isInterface(injectableType)
+              ? GeneratorKeys.get(injectableType)
+              : GeneratorKeys.rawMembersKey(injectableType);
+          linker.requestBinding(key, module.getQualifiedName().toString(), false, true);
         }
 
         // Gather the static injections.

--- a/compiler/src/main/java/dagger/internal/codegen/ProvidesProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/ProvidesProcessor.java
@@ -244,7 +244,9 @@ public final class ProvidesProcessor extends AbstractProcessor {
     StringBuilder injectsField = new StringBuilder().append("{ ");
     for (Object injectableType : injects) {
       TypeMirror typeMirror = (TypeMirror) injectableType;
-      String key = GeneratorKeys.rawMembersKey(typeMirror);
+      String key = CodeGen.isInterface(typeMirror)
+          ? GeneratorKeys.get(typeMirror)
+          : GeneratorKeys.rawMembersKey(typeMirror);
       injectsField.append(JavaWriter.stringLiteral(key)).append(", ");
     }
     injectsField.append("}");

--- a/core/src/main/java/dagger/ObjectGraph.java
+++ b/core/src/main/java/dagger/ObjectGraph.java
@@ -239,7 +239,7 @@ public abstract class ObjectGraph {
 
     @Override public <T> T get(Class<T> type) {
       String key = Keys.get(type);
-      String injectableTypeKey = Keys.getMembersKey(type);
+      String injectableTypeKey = type.isInterface() ? key : Keys.getMembersKey(type);
       @SuppressWarnings("unchecked") // The linker matches keys to bindings by their type.
       Binding<T> binding = (Binding<T>) getInjectableTypeBinding(injectableTypeKey, key);
       return binding.get();
@@ -255,8 +255,9 @@ public abstract class ObjectGraph {
 
     /**
      * @param injectableTypeKey the key used to store the injectable type. This
-     *     is always a members injection key because those keys can always be
-     *     created, even if the type has no injectable constructor.
+     *     is a provides key for interfaces and a members injection key for
+     *     other types. That way keys can always be created, even if the type
+     *     has no injectable constructor.
      * @param key the key to use when retrieving the binding. This may be a
      *     regular (provider) key or a members key.
      */

--- a/core/src/main/java/dagger/internal/plugins/reflect/ReflectiveModuleAdapter.java
+++ b/core/src/main/java/dagger/internal/plugins/reflect/ReflectiveModuleAdapter.java
@@ -39,7 +39,7 @@ final class ReflectiveModuleAdapter extends ModuleAdapter<Object> {
 
   public ReflectiveModuleAdapter(Class<?> moduleClass, Module annotation) {
     super(
-        toMemberKeys(annotation.injects()),
+        injectableTypesToKeys(annotation.injects()),
         annotation.staticInjections(),
         annotation.overrides(),
         annotation.includes(),
@@ -48,10 +48,13 @@ final class ReflectiveModuleAdapter extends ModuleAdapter<Object> {
     this.moduleClass = moduleClass;
   }
 
-  private static String[] toMemberKeys(Class<?>[] injectableTypes) {
+  private static String[] injectableTypesToKeys(Class<?>[] injectableTypes) {
     String[] result = new String[injectableTypes.length];
     for (int i = 0; i < injectableTypes.length; i++) {
-      result[i] = Keys.getMembersKey(injectableTypes[i]);
+      Class<?> injectableType = injectableTypes[i];
+      result[i] = injectableType.isInterface()
+          ? Keys.get(injectableType)
+          : Keys.getMembersKey(injectableType);
     }
     return result;
   }

--- a/core/src/test/java/dagger/InjectionTest.java
+++ b/core/src/test/java/dagger/InjectionTest.java
@@ -435,6 +435,24 @@ public final class InjectionTest {
     }
   }
 
+  @Test public void objectGraphGetInterface() {
+    final Runnable runnable = new Runnable() {
+      @Override public void run() {
+      }
+    };
+
+    @Module(injects = Runnable.class)
+    class TestModule {
+      @Provides Runnable provideRunnable() {
+        return runnable;
+      }
+    }
+
+    ObjectGraph graph = ObjectGraph.create(new TestModule());
+    graph.validate();
+    assertThat(graph.get(Runnable.class)).isSameAs(runnable);
+  }
+
   @Test public void noProvideBindingsForAbstractClasses() {
     class TestEntryPoint {
       @Inject AbstractList<?> abstractList;
@@ -563,8 +581,8 @@ public final class InjectionTest {
     }
 
     ObjectGraph graph = ObjectGraph.create(new TestModule());
-    assertEquals(0, (int) graph.get(Integer.class));
-    assertEquals(1, (int) graph.get(Integer.class));
+    assertThat((int) graph.get(Integer.class)).isEqualTo(0);
+    assertThat((int) graph.get(Integer.class)).isEqualTo(1);
   }
 
   @Test public void getInstanceRequiresEntryPoint() {


### PR DESCRIPTION
I admit that this fix is clumsy. The core problem is that
the 'injects' list serves double duty: it includes types that
we can call ObjectGraph.get() on (could be interfaces) and also
types that we call ObjectGraph.inject() on (can't be interfaces).

The right fix is to rethink the way Dagger internally tracks
and links these keys.
