### PR TITLE
Use two dollar signs between class name and dagger-generated suffix.

### DIFF
--- a/compiler/src/it/multiple-provides-methods/verify.bsh
+++ b/compiler/src/it/multiple-provides-methods/verify.bsh
@@ -2,11 +2,11 @@ import java.io.File;
 
 File classes = new File(basedir, "target/classes/test/");
 
-File moduleAdapter = new File(classes, "TestApp$TestModule$ModuleAdapter.class");
-if (!moduleAdapter.exists()) throw new Exception("No binding generated for module"); 
+File moduleAdapter = new File(classes, "TestApp$TestModule$$ModuleAdapter.class");
+if (!moduleAdapter.exists()) throw new Exception("No binding generated for module");
 
-File integerBinding = new File(classes, "TestApp$TestModule$ModuleAdapter$IntegerProvidesAdapter.class");
-if (!integerBinding.exists()) throw new Exception("No binding generated for integer()"); 
+File integerBinding = new File(classes, "TestApp$TestModule$$ModuleAdapter$IntegerProvidesAdapter.class");
+if (!integerBinding.exists()) throw new Exception("No binding generated for integer()");
 
-File stringBinding = new File(classes, "TestApp$TestModule$ModuleAdapter$StringProvidesAdapter.class");
-if (!stringBinding.exists()) throw new Exception("No binding generated for string()"); 
+File stringBinding = new File(classes, "TestApp$TestModule$$ModuleAdapter$StringProvidesAdapter.class");
+if (!stringBinding.exists()) throw new Exception("No binding generated for string()");

--- a/core/src/main/java/dagger/internal/plugins/loading/ClassloadingPlugin.java
+++ b/core/src/main/java/dagger/internal/plugins/loading/ClassloadingPlugin.java
@@ -25,9 +25,9 @@ import java.lang.reflect.Constructor;
  * A runtime {@link Plugin} that loads generated classes.
  */
 public final class ClassloadingPlugin implements Plugin {
-  public static final String INJECT_ADAPTER_SUFFIX = "$InjectAdapter";
-  public static final String MODULE_ADAPTER_SUFFIX = "$ModuleAdapter";
-  public static final String STATIC_INJECTION_SUFFIX = "$StaticInjection";
+  public static final String INJECT_ADAPTER_SUFFIX = "$$InjectAdapter";
+  public static final String MODULE_ADAPTER_SUFFIX = "$$ModuleAdapter";
+  public static final String STATIC_INJECTION_SUFFIX = "$$StaticInjection";
 
   @Override public <T> ModuleAdapter<T> getModuleAdapter(Class<? extends T> moduleClass, T module) {
     return instantiate(moduleClass.getName(), MODULE_ADAPTER_SUFFIX);


### PR DESCRIPTION
This prevents the extremely rare (but possible) case where a generated class for a type has naming conflicts with a static inner class on that same type.
