### PR TITLE
Fix issues with problem detector when used at runtime.

### DIFF
--- a/compiler/src/it/unused-provider-methods-fail-compilation/verify.bsh
+++ b/compiler/src/it/unused-provider-methods-fail-compilation/verify.bsh
@@ -4,6 +4,6 @@ import java.io.File;
 File buildLog = new File(basedir, "build.log");
 new BuildLogValidator().assertHasText(buildLog, new String[]{
     "You have these unused @Provider methods:",
-    "0. test.TestModule.string()",
+    "1. test.TestModule.string()",
     "Set library=true in your module to disable this check."
     });

--- a/compiler/src/main/java/dagger/internal/codegen/ProvidesProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/ProvidesProcessor.java
@@ -420,8 +420,9 @@ public final class ProvidesProcessor extends AbstractProcessor {
     boolean singleton = providerMethod.getAnnotation(Singleton.class) != null;
     String key = JavaWriter.stringLiteral(GeneratorKeys.get(providerMethod));
     String membersKey = null;
-    writer.emitStatement("super(%s, %s, %s, %s.class)",
-        key, membersKey, (singleton ? "IS_SINGLETON" : "NOT_SINGLETON"), moduleType);
+    writer.emitStatement("super(%s, %s, %s, %s)",
+        key, membersKey, (singleton ? "IS_SINGLETON" : "NOT_SINGLETON"),
+        JavaWriter.stringLiteral(moduleType + "." + methodName + "()"));
     writer.emitStatement("this.module = module");
     writer.emitStatement("setLibrary(%s)", library);
     writer.endMethod();

--- a/core/src/main/java/dagger/internal/Linker.java
+++ b/core/src/main/java/dagger/internal/Linker.java
@@ -328,12 +328,28 @@ public final class Linker {
       return binding.isVisiting();
     }
 
+    @Override public boolean library() {
+      return binding.library();
+    }
+
+    @Override public boolean dependedOn() {
+      return binding.dependedOn();
+    }
+
     @Override public void setCycleFree(final boolean cycleFree) {
       binding.setCycleFree(cycleFree);
     }
 
     @Override public void setVisiting(final boolean visiting) {
       binding.setVisiting(visiting);
+    }
+
+    @Override public void setLibrary(boolean library) {
+      binding.setLibrary(true);
+    }
+
+    @Override public void setDependedOn(boolean dependedOn) {
+      binding.setDependedOn(dependedOn);
     }
 
     @Override protected boolean isSingleton() {

--- a/core/src/main/java/dagger/internal/ProblemDetector.java
+++ b/core/src/main/java/dagger/internal/ProblemDetector.java
@@ -40,7 +40,8 @@ public final class ProblemDetector {
       StringBuilder builder = new StringBuilder();
       builder.append("You have these unused @Provider methods:");
       for (int i = 0; i < unusedBindings.size(); i++) {
-        builder.append("\n    ").append(i).append(". ").append(unusedBindings.get(i).requiredBy);
+        builder.append("\n    ").append(i + 1).append(". ")
+            .append(unusedBindings.get(i).requiredBy);
       }
       builder.append("\n    Set library=true in your module to disable this check.");
       throw new IllegalStateException(builder.toString());


### PR DESCRIPTION
We weren't tracking library & dependedOn state properly for the
singleton wrapper. We also require a more strict format for
requiredBy: it must be the provider method name.

Also number the errors from 1. We number the cycles from 0 because
the last element in that list is equal to the first element.
