### PR TITLE
Don't create objects unless there's an @Inject annotation.

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/CompileTimePlugin.java
+++ b/compiler/src/main/java/dagger/internal/codegen/CompileTimePlugin.java
@@ -38,7 +38,7 @@ public final class CompileTimePlugin implements Plugin {
   }
 
   @Override public Binding<?> getAtInjectBinding(
-      String key, String className, boolean mustBeInjectable) {
+      String key, String className, boolean mustHaveInjections) {
     String sourceClassName = className.replace('$', '.');
     TypeElement type = processingEnv.getElementUtils().getTypeElement(sourceClassName);
     if (type == null) {
@@ -51,7 +51,7 @@ public final class CompileTimePlugin implements Plugin {
     if (type.getKind() == ElementKind.INTERFACE) {
       return null;
     }
-    return AtInjectBinding.create(type, mustBeInjectable);
+    return AtInjectBinding.create(type, mustHaveInjections);
   }
 
   @Override public <T> ModuleAdapter<T> getModuleAdapter(Class<? extends T> moduleClass, T module) {

--- a/core/src/main/java/dagger/internal/Linker.java
+++ b/core/src/main/java/dagger/internal/Linker.java
@@ -101,12 +101,12 @@ public final class Linker {
       if (binding instanceof DeferredBinding) {
         DeferredBinding deferredBinding = (DeferredBinding) binding;
         String key = deferredBinding.deferredKey;
-        boolean mustBeInjectable = deferredBinding.mustBeInjectable;
+        boolean mustHaveInjections = deferredBinding.mustHaveInjections;
         if (bindings.containsKey(key)) {
           continue; // A binding for this key has since been linked.
         }
         try {
-          Binding<?> jitBinding = createJitBinding(key, binding.requiredBy, mustBeInjectable);
+          Binding<?> jitBinding = createJitBinding(key, binding.requiredBy, mustHaveInjections);
           jitBinding.setLibrary(binding.library());
           jitBinding.setDependedOn(binding.dependedOn());
           // Fail if the type of binding we got wasn't capable of what was requested.
@@ -167,7 +167,7 @@ public final class Linker {
    *   <li>Injections of other types will use the injectable constructors of those classes.
    * </ul>
    */
-  private Binding<?> createJitBinding(String key, Object requiredBy, boolean mustBeInjectable)
+  private Binding<?> createJitBinding(String key, Object requiredBy, boolean mustHaveInjections)
       throws ClassNotFoundException {
     String builtInBindingsKey = Keys.getBuiltInBindingsKey(key);
     if (builtInBindingsKey != null) {
@@ -180,7 +180,7 @@ public final class Linker {
 
     String className = Keys.getClassName(key);
     if (className != null && !Keys.isAnnotated(key)) {
-      Binding<?> atInjectBinding = plugin.getAtInjectBinding(key, className, mustBeInjectable);
+      Binding<?> atInjectBinding = plugin.getAtInjectBinding(key, className, mustHaveInjections);
       if (atInjectBinding != null) {
         return atInjectBinding;
       }
@@ -203,12 +203,13 @@ public final class Linker {
    * null. If the returned binding didn't exist or was unlinked, it will be
    * enqueued to be linked.
    *
-   * @param mustBeInjectable true if the the referenced key doesn't need to be
-   *     injectable. This is necessary for injectable types (so that framework
-   *     code can inject arbitrary classes like JUnit test cases or Android
-   *     activities) and also for supertypes.
+   * @param mustHaveInjections true if the the referenced key requires either an
+   *     {@code @Inject} annotation is produced by a {@code @Provides} method.
+   *     This isn't necessary for Module.injects types because frameworks need
+   *     to inject arbitrary classes like JUnit test cases and Android
+   *     activities. It also isn't necessary for supertypes.
    */
-  public Binding<?> requestBinding(String key, Object requiredBy, boolean mustBeInjectable,
+  public Binding<?> requestBinding(String key, Object requiredBy, boolean mustHaveInjections,
       boolean library) {
     assertLockHeld();
 
@@ -223,7 +224,7 @@ public final class Linker {
 
     if (binding == null) {
       // We can't satisfy this binding. Make sure it'll work next time!
-      Binding<?> deferredBinding = new DeferredBinding(key, requiredBy, mustBeInjectable);
+      Binding<?> deferredBinding = new DeferredBinding(key, requiredBy, mustHaveInjections);
       deferredBinding.setLibrary(library);
       deferredBinding.setDependedOn(true);
       toLink.add(deferredBinding);
@@ -384,12 +385,12 @@ public final class Linker {
 
   private static class DeferredBinding extends Binding<Object> {
     final String deferredKey;
-    final boolean mustBeInjectable;
+    final boolean mustHaveInjections;
 
-    private DeferredBinding(String deferredKey, Object requiredBy, boolean mustBeInjectable) {
+    private DeferredBinding(String deferredKey, Object requiredBy, boolean mustHaveInjections) {
       super(null, null, false, requiredBy);
       this.deferredKey = deferredKey;
-      this.mustBeInjectable = mustBeInjectable;
+      this.mustHaveInjections = mustHaveInjections;
     }
     @Override public void injectMembers(Object t) {
       throw new UnsupportedOperationException("Deferred bindings must resolve first.");

--- a/core/src/main/java/dagger/internal/Plugin.java
+++ b/core/src/main/java/dagger/internal/Plugin.java
@@ -24,7 +24,7 @@ public interface Plugin {
   /**
    * Returns a binding that uses {@code @Inject} annotations.
    */
-  Binding<?> getAtInjectBinding(String key, String className, boolean mustBeInjectable);
+  Binding<?> getAtInjectBinding(String key, String className, boolean mustHaveInjections);
 
   /**
    * Returns a module adapter for {@code module}.

--- a/core/src/main/java/dagger/internal/RuntimeAggregatingPlugin.java
+++ b/core/src/main/java/dagger/internal/RuntimeAggregatingPlugin.java
@@ -107,10 +107,10 @@ public final class RuntimeAggregatingPlugin implements Plugin {
   }
 
   @Override public Binding<?> getAtInjectBinding(String key, String className,
-      boolean mustBeInjectable) {
+      boolean mustHaveInjections) {
     for (int i = 0; i < plugins.length; i++) {
       try {
-        return plugins[i].getAtInjectBinding(key, className, mustBeInjectable);
+        return plugins[i].getAtInjectBinding(key, className, mustHaveInjections);
       } catch (RuntimeException e) {
         if (i == plugins.length - 1) throw e;
         logNotFound("Binding", className, e);

--- a/core/src/main/java/dagger/internal/plugins/loading/ClassloadingPlugin.java
+++ b/core/src/main/java/dagger/internal/plugins/loading/ClassloadingPlugin.java
@@ -34,7 +34,7 @@ public final class ClassloadingPlugin implements Plugin {
   }
 
   @Override public Binding<?> getAtInjectBinding(
-      String key, String className, boolean mustBeInjectable) {
+      String key, String className, boolean mustHaveInjections) {
     return instantiate(className, INJECT_ADAPTER_SUFFIX);
   }
 

--- a/core/src/main/java/dagger/internal/plugins/reflect/ReflectiveAtInjectBinding.java
+++ b/core/src/main/java/dagger/internal/plugins/reflect/ReflectiveAtInjectBinding.java
@@ -139,11 +139,7 @@ final class ReflectiveAtInjectBinding<T> extends Binding<T> {
     return provideKey != null ? provideKey : membersKey;
   }
 
-  /**
-   * @param mustBeInjectable true if the binding must have {@code @Inject}
-   *     annotations.
-   */
-  public static <T> Binding<T> create(Class<T> type, boolean mustBeInjectable) {
+  public static <T> Binding<T> create(Class<T> type, boolean mustHaveInjections) {
     boolean singleton = type.isAnnotationPresent(Singleton.class);
     List<String> keys = new ArrayList<String>();
 
@@ -177,13 +173,14 @@ final class ReflectiveAtInjectBinding<T> extends Binding<T> {
       injectedConstructor = constructor;
     }
     if (injectedConstructor == null) {
-      if (injectedFields.isEmpty() && mustBeInjectable) {
+      if (!injectedFields.isEmpty()) {
+        try {
+          injectedConstructor = type.getDeclaredConstructor();
+        } catch (NoSuchMethodException ignored) {
+        }
+      } else if (mustHaveInjections) {
         throw new IllegalArgumentException("No injectable members on " + type.getName()
             + ". Do you want to add an injectable constructor?");
-      }
-      try {
-        injectedConstructor = type.getDeclaredConstructor();
-      } catch (NoSuchMethodException ignored) {
       }
     }
 

--- a/core/src/main/java/dagger/internal/plugins/reflect/ReflectivePlugin.java
+++ b/core/src/main/java/dagger/internal/plugins/reflect/ReflectivePlugin.java
@@ -31,7 +31,7 @@ import javax.inject.Inject;
  */
 public final class ReflectivePlugin implements Plugin {
   @Override public Binding<?> getAtInjectBinding(
-      String key, String className, boolean mustBeInjectable) {
+      String key, String className, boolean mustHaveInjections) {
     Class<?> c;
     try {
       c = Class.forName(className);
@@ -43,7 +43,7 @@ public final class ReflectivePlugin implements Plugin {
       return null;
     }
 
-    return ReflectiveAtInjectBinding.create(c, mustBeInjectable);
+    return ReflectiveAtInjectBinding.create(c, mustHaveInjections);
   }
 
   @SuppressWarnings("unchecked") // Runtime checks validate that the result type matches 'T'.

--- a/core/src/test/java/dagger/InjectionTest.java
+++ b/core/src/test/java/dagger/InjectionTest.java
@@ -17,6 +17,7 @@
 package dagger;
 
 import java.util.AbstractList;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.RandomAccess;
@@ -822,6 +823,22 @@ public final class InjectionTest {
       fail();
     } catch (IllegalStateException e) {
       assertThat(e.getMessage()).contains("Can't inject private constructor: ");
+    }
+  }
+
+  /** https://github.com/square/dagger/issues/231 */
+  @Test public void atInjectAlwaysRequiredForConstruction() {
+    @Module(injects = ArrayList.class)
+    class TestModule {
+    }
+
+    ObjectGraph objectGraph = ObjectGraph.create(new TestModule());
+    objectGraph.validate();
+    try {
+      objectGraph.get(ArrayList.class);
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e.getMessage()).contains("Unable to create binding for java.util.ArrayList");
     }
   }
 }


### PR DESCRIPTION
We had a bug in our handling of entry points where we'd
use the no-args constructor even if there were no injected
fields present.
