### PR TITLE
Bump JavaWriter to v1.0.5.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <!-- Compilation -->
     <java.version>1.6</java.version>
     <javax.inject.version>1</javax.inject.version>
-    <javawriter.version>1.0.2</javawriter.version>
+    <javawriter.version>1.0.5</javawriter.version>
 
     <!-- Test Dependencies -->
     <junit.version>4.10</junit.version>


### PR DESCRIPTION
This fixes #239 where the code gen for a class named `Provider` would incorrectly
be confused with Dagger's `Provider` which was already an import.
