### PR TITLE
Could not find tool 'aapt' error after updating android sdk

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -65,13 +65,20 @@
   </dependencyManagement>
 
   <!-- Example-only plugins -->
+  <pluginRepositories>
+    <pluginRepository>
+      <id>jayway.snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/jayway-snapshots</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <build>
     <pluginManagement>
       <plugins>
         <plugin>
           <groupId>com.jayway.maven.plugins.android.generation2</groupId>
           <artifactId>android-maven-plugin</artifactId>
-          <version>3.5.3</version>
+          <version>3.5.4-SNAPSHOT</version>
           <configuration>
             <sdk>
               <platform>16</platform>


### PR DESCRIPTION
after running `android update sdk`, the build breaks on android simple with a `Could not find tool 'aapt'` error.  This is fixed upstream in  https://github.com/jayway/maven-android-plugin/pull/205

The current commit switches to a snapshot until android-maven-plugin 3.5.4 is out
