### PR TITLE
Helpful error message if someone puts @Inject on a class, not NPE

### DIFF
--- a/compiler/src/it/inject-on-class/invoker.properties
+++ b/compiler/src/it/inject-on-class/invoker.properties
@@ -1,0 +1,1 @@
+invoker.buildResult=failure

--- a/compiler/src/it/inject-on-class/pom.xml
+++ b/compiler/src/it/inject-on-class/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2013 Square, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>method-injection</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/inject-on-class/src/main/java/test/TestApp.java
+++ b/compiler/src/it/inject-on-class/src/main/java/test/TestApp.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import javax.inject.Inject;
+
+@Inject
+class TestApp {
+}

--- a/compiler/src/it/inject-on-class/verify.bsh
+++ b/compiler/src/it/inject-on-class/verify.bsh
@@ -1,0 +1,6 @@
+import dagger.testing.it.BuildLogValidator;
+import java.io.File;
+
+File buildLog = new File(basedir, "build.log");
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "@Inject is not valid on a class: test.TestApp"});

--- a/compiler/src/main/java/dagger/internal/codegen/InjectProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/InjectProcessor.java
@@ -127,6 +127,11 @@ public final class InjectProcessor extends AbstractProcessor {
   private boolean validateInjectable(Element injectable) {
     Element injectableType = injectable.getEnclosingElement();
 
+    if (injectable.getKind() == ElementKind.CLASS) {
+      error("@Inject is not valid on a class: " + injectable, injectable);
+      return false;
+    }
+
     if (injectable.getKind() == ElementKind.METHOD) {
       error("Method injection is not supported: " + injectableType + "." + injectable, injectable);
       return false;


### PR DESCRIPTION
If someone is silly enough to put @Inject on a class, they might expect an error telling them not to. However, the annotation processor runs on this dodgy code and the InjectProcessor gets given this to deal with. It was throwing a NullPointerException which took some time to track down, so I've put in a simple little check for it and made it report a nice helpful error message instead. I've added a test for this too.
