### PR TITLE
backfill set binding contribution tests

### DIFF
--- a/compiler/src/it/set-binding-iteration/pom.xml
+++ b/compiler/src/it/set-binding-iteration/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (C) 2012 Square, Inc.
+ Copyright (C) 2012 Google, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>set-binding-iteration</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <name>Dagger Integration Test Basic</name>
+  <properties>
+    <junit.version>4.10</junit.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/set-binding-iteration/src/main/java/test/FirstStringFromSetBinding.java
+++ b/compiler/src/it/set-binding-iteration/src/main/java/test/FirstStringFromSetBinding.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2012 Google, Inc.
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.Module;
+import dagger.Provides;
+
+import java.util.Set;
+import javax.inject.Inject;
+
+import static dagger.Provides.Type.SET;
+
+class FirstStringFromSetBinding {
+  String string;
+
+  @Inject
+  FirstStringFromSetBinding(Set<String> strings) {
+    this.string = strings.iterator().next();
+  }
+
+  @Module(injects = FirstStringFromSetBinding.class)
+  static class String1Module {
+    @Provides(type = SET)
+    String provideFirstString() {
+      return "string1";
+    }
+  }
+
+  @Module(injects = FirstStringFromSetBinding.class)
+  static class String2Module {
+    @Provides(type = SET)
+    String provideSecondString() {
+      return "string2";
+    }
+  }
+
+  @Module(injects = FirstStringFromSetBinding.class, includes = String1Module.class)
+  static class IncludeString1Module {
+  }
+}

--- a/compiler/src/it/set-binding-iteration/src/test/java/test/SetBindingTest.java
+++ b/compiler/src/it/set-binding-iteration/src/test/java/test/SetBindingTest.java
@@ -1,0 +1,35 @@
+package test;
+
+import dagger.ObjectGraph;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static dagger.Provides.Type.SET;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(JUnit4.class)
+public final class SetBindingTest {
+
+  @Test
+  public void testOrderOfCompileProcessedSetBindings()  throws Exception {
+    // ensure the compile task operated against this
+    assertNotNull(Class.forName(FirstStringFromSetBinding.class.getName() + "$$InjectAdapter"));
+
+    FirstStringFromSetBinding ep = ObjectGraph
+        .create(new FirstStringFromSetBinding.String1Module(), new FirstStringFromSetBinding.String2Module())
+        .get(FirstStringFromSetBinding.class);
+    assertEquals("string1", ep.string);
+  }
+
+  @Test
+  public void testOrderOfCompileProcessedSetBindingsWithIncludedSetBinding() {
+    FirstStringFromSetBinding ep = ObjectGraph
+        .create(new FirstStringFromSetBinding.IncludeString1Module(), new FirstStringFromSetBinding.String2Module())
+        .get(FirstStringFromSetBinding.class);
+    assertEquals("string2", ep.string);
+  }
+}


### PR DESCRIPTION
Closes issue #252, verifying there's no difference between reflective and annotation processed set bindings.  In both cases, contribution is breadth-first wrt Module.includes.
