### PR TITLE
Don't throw ClassCastException on certain compile errors.

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/ProvidesProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/ProvidesProcessor.java
@@ -120,11 +120,11 @@ public final class ProvidesProcessor extends AbstractProcessor {
     for (Element providerMethod : providesMethods(env)) {
       switch (providerMethod.getEnclosingElement().getKind()) {
         case CLASS:
-            break; // valid, move along
+          break; // valid, move along
         default:
-            // TODO(tbroyer): pass annotation information
-            error("Unexpected @Provides on " + providerMethod, providerMethod);
-            continue;
+          // TODO(tbroyer): pass annotation information
+          error("Unexpected @Provides on " + providerMethod, providerMethod);
+          continue;
       }
       TypeElement type = (TypeElement) providerMethod.getEnclosingElement();
       Set<Modifier> typeModifiers = type.getModifiers();


### PR DESCRIPTION
Handle the failure of compilation better, so we don't find out because of a ClassCastException on a TypeElement.  

This can happen when the element fails compilation in certain ways (say, missing symbols from using the wrong android SDK version, etc.).  The compiler hands the Processor a bum AST which seems to put `@Provides` annotations structurally on the class (normally quite impossible).  The resulting error is obscure and doesn't show which class the problem is occurring on.  

This change simply validates the structure (and the implicit assumption of the cast) before performing the cast, so an error is trapped and reported, not thrown within the compilation job.

I haven't been able to replicate this in a simple consistent test, sadly, or I would include it here, but this code, in the real error inside google, resulted in the correct error being obvious.  If nothing else, we should never be in a position where we throw out of a compilation/processing job, as that shuts down error reporting.  
