### PR TITLE
Support building against the Android SDK in continuous integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - tar -xzf android-sdk_r21.0.1-linux.tgz
   - export ANDROID_HOME=${PWD}/android-sdk-linux
   - export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
-  - android update sdk --filter platform-tools,android-16,extra-android-support,android-17,sysimg-17 --no-ui --force
+  - android update sdk --filter platform-tools,android-16 --no-ui --force
 
 install: mvn install clean --fail-never --quiet -DskipTests=true -Dinvoker.skip=true
 


### PR DESCRIPTION
A configuration to permit Travis-ci to install the android SDK before running continuous build.
