### PR TITLE
Support all annotations, since some JVMs don't consistently fire the processor.

### DIFF
--- a/compiler/src/it/provide-provider-or-lazy/verify.bsh
+++ b/compiler/src/it/provide-provider-or-lazy/verify.bsh
@@ -3,10 +3,10 @@ import java.io.File;
 
 File buildLog = new File(basedir, "build.log");
 new BuildLogValidator().assertHasText(buildLog, new String[]{
-    "@Provides method must not return Provider directly: test.TestModule.provideProvider"});
+    "@Provides method must not return javax.inject.Provider directly: test.TestModule.provideProvider"});
 new BuildLogValidator().assertHasText(buildLog, new String[]{
-    "@Provides method must not return Provider directly: test.TestModule.provideRawProvider"});
+    "@Provides method must not return javax.inject.Provider directly: test.TestModule.provideRawProvider"});
 new BuildLogValidator().assertHasText(buildLog, new String[]{
-    "@Provides method must not return Lazy directly: test.TestModule.provideLazy"});
+    "@Provides method must not return dagger.Lazy directly: test.TestModule.provideLazy"});
 new BuildLogValidator().assertHasText(buildLog, new String[]{
-    "@Provides method must not return Lazy directly: test.TestModule.provideRawLazy"});
+    "@Provides method must not return dagger.Lazy directly: test.TestModule.provideRawLazy"});

--- a/compiler/src/main/java/dagger/internal/codegen/ModuleAdapterProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/ModuleAdapterProcessor.java
@@ -24,6 +24,7 @@ import dagger.internal.ModuleAdapter;
 import dagger.internal.SetBinding;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -69,7 +70,7 @@ import static java.lang.reflect.Modifier.STATIC;
  * Generates an implementation of {@link ModuleAdapter} that includes a binding
  * for each {@code @Provides} method of a target class.
  */
-@SupportedAnnotationTypes({ "dagger.Provides", "dagger.Module" })
+@SupportedAnnotationTypes({ "*" })
 public final class ModuleAdapterProcessor extends AbstractProcessor {
   private final LinkedHashMap<String, List<ExecutableElement>> remainingTypes =
       new LinkedHashMap<String, List<ExecutableElement>>();
@@ -118,11 +119,6 @@ public final class ModuleAdapterProcessor extends AbstractProcessor {
     Elements elementUtils = processingEnv.getElementUtils();
     Types types = processingEnv.getTypeUtils();
 
-    TypeElement providerElement = elementUtils.getTypeElement("javax.inject.Provider");
-    TypeMirror providerType = types.erasure(providerElement.asType());
-    TypeElement lazyElement = elementUtils.getTypeElement("dagger.Lazy");
-    TypeMirror lazyType = types.erasure(lazyElement.asType());
-
     Map<String, List<ExecutableElement>> result = new HashMap<String, List<ExecutableElement>>();
     for (Element providerMethod : providesMethods(env)) {
       switch (providerMethod.getEnclosingElement().getKind()) {
@@ -158,20 +154,17 @@ public final class ModuleAdapterProcessor extends AbstractProcessor {
         continue;
       }
 
+      // Invalidate return types.
       TypeMirror returnType = types.erasure(providerMethodAsExecutable.getReturnType());
-      if (types.isSameType(returnType, providerType)) {
-        error("@Provides method must not return Provider directly: "
-            + type.getQualifiedName()
-            + "."
-            + providerMethod, providerMethod);
-        continue;
-      }
-      if (types.isSameType(returnType, lazyType)) {
-        error("@Provides method must not return Lazy directly: "
-            + type.getQualifiedName()
-            + "."
-            + providerMethod, providerMethod);
-        continue;
+      for (String invalidTypeName : Arrays.asList("javax.inject.Provider", "dagger.Lazy")) {
+        TypeElement invalidTypeElement = elementUtils.getTypeElement(invalidTypeName);
+        if (invalidTypeElement != null) {
+          if (types.isSameType(returnType, types.erasure(invalidTypeElement.asType()))) {
+            error(String.format("@Provides method must not return %s directly: %s.%s",
+                invalidTypeElement, type.getQualifiedName(), providerMethod), providerMethod);
+            continue; // skip to next provides method.
+          }
+        }
       }
 
       List<ExecutableElement> methods = result.get(type.getQualifiedName().toString());


### PR DESCRIPTION
Support all annotations, since some JVMs (or patched vm's) will only cause the module processor to run if that compilation job includes classes that have both `@dagger.Provides` and `@dagger.Module`.

Ultimately, I want to re-write this to collect everything from the module, as it will be faster than supporting "*", and in any case, it is really the `@Module` that we start from, not the `@Provides` method.  But this is a quick-fix that should be functionality-neutral for everyone to get us over the hump. 
