### PR TITLE
add Provides.Type.SET_VALUES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+Version 1.1.0 *(TBD)*
+----------------------------
+
+ * Allow multiple contributions to Set binding via `Provides.Type.SET_VALUES`
+
+
 Version 1.0.1 *(2013-06-03)*
 ----------------------------
 

--- a/compiler/src/it/extension-graph-setvalues/pom.xml
+++ b/compiler/src/it/extension-graph-setvalues/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (C) 2013 Square, Inc.
+ Copyright (C) 2013 Google, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>extension-graph-setvalues</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <name>Dagger Integration Test Basic</name>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/extension-graph-setvalues/src/main/java/test/TestApp.java
+++ b/compiler/src/it/extension-graph-setvalues/src/main/java/test/TestApp.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.ObjectGraph;
+import dagger.Module;
+import dagger.Provides;
+import java.util.HashSet;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import static dagger.Provides.Type.SET;
+import static dagger.Provides.Type.SET_VALUES;
+
+/**
+ * Contributions to {@code SET_VALUES} binding do not affect Set of providers.
+ */
+class TestApp implements Runnable {
+  @Inject Set<Provider<String>> providers;
+  @Inject Set<String> strings;
+
+  @Override public void run() {
+    System.out.println(strings);
+  }
+
+  public static void main(String[] args) {
+    ObjectGraph root = ObjectGraph.create(new RootModule());
+    ObjectGraph extension = root.plus(new ExtensionModule());
+    extension.get(TestApp.class).run();
+  }
+  
+  @Module(injects = TestApp.class)
+  static class RootModule {
+    @Provides Set<Provider<String>> providers() {
+      return new HashSet<Provider<String>>();
+    }
+    @Provides(type = SET_VALUES) Set<String> strings() {
+      return new HashSet<String>();
+    }
+  }
+
+  @Module(addsTo = RootModule.class, injects = TestApp.class)
+  static class ExtensionModule {
+    @Provides(type = SET) String addToSet() {
+      return "contributed";
+    }
+  }
+}

--- a/compiler/src/it/multiple-modules-setvalues/pom.xml
+++ b/compiler/src/it/multiple-modules-setvalues/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (C) 2013 Square, Inc.
+ Copyright (C) 2013 Google, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>multiple-modules-setvalues</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <name>Dagger Integration Test Basic</name>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/multiple-modules-setvalues/src/main/java/test/TestApp.java
+++ b/compiler/src/it/multiple-modules-setvalues/src/main/java/test/TestApp.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.ObjectGraph;
+import dagger.Module;
+import dagger.Provides;
+import java.util.HashSet;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import static dagger.Provides.Type.SET;
+import static dagger.Provides.Type.SET_VALUES;
+
+/**
+ * Contributions to {@code SET_VALUES} binding do not affect Set of providers.
+ */
+class TestApp implements Runnable {
+  @Inject Set<Provider<String>> providers;
+  @Inject Set<String> strings;
+
+  @Override public void run() {
+    System.out.println(strings);
+  }
+
+  public static void main(String[] args) {
+    ObjectGraph root = ObjectGraph.create(new RootModule(), new ContributingModule());
+    root.get(TestApp.class).run();
+  }
+  
+  @Module(injects = TestApp.class)
+  static class RootModule {
+    @Provides Set<Provider<String>> providers() {
+      return new HashSet<Provider<String>>();
+    }
+    @Provides(type = SET_VALUES) Set<String> strings() {
+      return new HashSet<String>();
+    }
+  }
+
+  @Module(injects = TestApp.class, complete = false)
+  static class ContributingModule {
+    @Provides(type = SET) String addToSet() {
+      return "contributed";
+    }
+  }
+}

--- a/compiler/src/main/java/dagger/internal/codegen/GraphAnalysisProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/GraphAnalysisProcessor.java
@@ -51,6 +51,8 @@ import javax.tools.FileObject;
 import javax.tools.JavaFileManager;
 import javax.tools.StandardLocation;
 
+import static dagger.Provides.Type.SET;
+import static dagger.Provides.Type.SET_VALUES;
 import static dagger.internal.codegen.TypeUtils.getAnnotation;
 import static dagger.internal.codegen.TypeUtils.getPackage;
 import static dagger.internal.codegen.TypeUtils.isInterface;
@@ -184,7 +186,8 @@ public final class GraphAnalysisProcessor extends AbstractProcessor {
 
           Binding previous = addTo.get(key);
           if (previous != null) {
-            if (provides.type() == Provides.Type.SET && previous instanceof SetBinding) {
+            if ((provides.type() == SET || provides.type() == SET_VALUES)
+                && previous instanceof SetBinding) {
               // No duplicate bindings error if both bindings are set bindings.
             } else {
               String message = "Duplicate bindings for " + key;
@@ -204,6 +207,10 @@ public final class GraphAnalysisProcessor extends AbstractProcessor {
             case SET:
               String setKey = GeneratorKeys.getSetKey(providerMethod);
               SetBinding.add(addTo, setKey, binding);
+              break;
+
+            case SET_VALUES:
+              SetBinding.add(addTo, key, binding);
               break;
 
             default:

--- a/compiler/src/main/java/dagger/internal/codegen/ModuleAdapterProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/ModuleAdapterProcessor.java
@@ -51,6 +51,8 @@ import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
 import javax.tools.JavaFileObject;
 
+import static dagger.Provides.Type.SET;
+import static dagger.Provides.Type.SET_VALUES;
 import static dagger.internal.codegen.AdapterJavadocs.binderTypeDocs;
 import static dagger.internal.codegen.TypeUtils.adapterName;
 import static dagger.internal.codegen.TypeUtils.getAnnotation;
@@ -319,6 +321,13 @@ public final class ModuleAdapterProcessor extends AbstractProcessor {
                 bindingClassName(providerMethod, methodToClassName, methodNameToNextId));
             break;
           }
+          case SET_VALUES: {
+            String key = GeneratorKeys.get(providerMethod);
+            writer.emitStatement("SetBinding.add(map, %s, new %s(module))",
+                JavaWriter.stringLiteral(key),
+                bindingClassName(providerMethod, methodToClassName, methodNameToNextId));
+            break;
+          }
           default:
             throw new AssertionError("Unknown @Provides type " + provides.type());
         }
@@ -364,7 +373,8 @@ public final class ModuleAdapterProcessor extends AbstractProcessor {
 
   private boolean checkForMultibindings(List<ExecutableElement> providerMethods) {
     for (ExecutableElement element : providerMethods) {
-      if (element.getAnnotation(Provides.class).type() == Provides.Type.SET) {
+      Provides.Type providesType = element.getAnnotation(Provides.class).type();
+      if (providesType == SET || providesType == SET_VALUES) {
         return true;
       }
     }

--- a/core/src/main/java/dagger/Provides.java
+++ b/core/src/main/java/dagger/Provides.java
@@ -46,7 +46,14 @@ public @interface Provides {
      * method as parameters. The {@code Set<T>} produced from the accumulation of values will be
      * immutable.
      */
-    SET
+    SET,
+
+    /**
+     * Like {@link #SET}, except the method's return type is {@code Set<T>}, where any values are
+     * contributed to the set. An example use is to provide a default empty set binding, which is
+     * otherwise not possible using {@link #SET}.
+     */
+    SET_VALUES;
   }
 
   Type type() default Type.UNIQUE;

--- a/core/src/main/java/dagger/internal/SetBinding.java
+++ b/core/src/main/java/dagger/internal/SetBinding.java
@@ -55,11 +55,16 @@ public final class SetBinding<T> extends Binding<Set<T>> {
     }
   }
 
-  @SuppressWarnings("unchecked") // Bindings<T> are the only thing added to contributors.
+  @SuppressWarnings("unchecked") // Only Binding<T> and Set<T> are added to contributors.
   @Override public Set<T> get() {
     Set<T> result = new LinkedHashSet<T>(contributors.size());
     for (Binding<?> contributor : contributors) {
-      result.add((T) contributor.get()); // Let runtime exceptions through.
+      Object contribution = contributor.get(); // Let runtime exceptions through.
+      if (contributor.provideKey.equals(provideKey)) {
+        result.addAll((Set<T>) contribution);
+      } else {
+        result.add((T) contribution);
+      }
     }
     return Collections.unmodifiableSet(result);
   }

--- a/core/src/test/java/dagger/UnusedProviderTest.java
+++ b/core/src/test/java/dagger/UnusedProviderTest.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.Set;
+
 import static org.junit.Assert.fail;
 
 @RunWith(JUnit4.class)
@@ -85,6 +87,22 @@ public class UnusedProviderTest {
     @Module
     class TestModule {
       @Provides(type = Provides.Type.SET) String provideA() {
+        throw new AssertionError();
+      }
+    }
+
+    ObjectGraph graph = ObjectGraph.createWith(new TestingLoader(), new TestModule());
+    try {
+      graph.validate();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+  }
+
+  @Test public void unusedSetValuesBinding() throws Exception {
+    @Module
+    class TestModule {
+      @Provides(type = Provides.Type.SET_VALUES) Set<String> provideA() {
         throw new AssertionError();
       }
     }

--- a/core/src/test/java/dagger/internal/TestingModuleAdapter.java
+++ b/core/src/test/java/dagger/internal/TestingModuleAdapter.java
@@ -85,7 +85,12 @@ public class TestingModuleAdapter<M> extends ModuleAdapter<M> {
               handleBindings(bindings, method, key, library);
               break;
             case SET:
-              handleSetBindings(bindings, method, key, library);
+              String setKey = Keys.getSetKey(method.getGenericReturnType(),
+                  method.getAnnotations(), method);
+              handleSetBindings(bindings, method, setKey, key, library);
+              break;
+            case SET_VALUES:
+              handleSetBindings(bindings, method, key, key, library);
               break;
             default:
               throw new AssertionError("Unknown @Provides type " + provides.type());
@@ -100,11 +105,9 @@ public class TestingModuleAdapter<M> extends ModuleAdapter<M> {
     bindings.put(key, new ProviderMethodBinding<M>(method, key, module, library));
   }
 
-  private void handleSetBindings(Map<String, Binding<?>> bindings, Method method, String key,
-      boolean library) {
-    String setKey = Keys.getSetKey(method.getGenericReturnType(), method.getAnnotations(), method);
-    SetBinding.<M>add(bindings, setKey, new ProviderMethodBinding<M>(method, key, module,
-        library));
+  private void handleSetBindings(Map<String, Binding<?>> bindings, Method method, String setKey,
+      String providerKey, boolean library) {
+    SetBinding.<M>add(bindings, setKey, new ProviderMethodBinding<M>(method, providerKey, module, library));
   }
 
   @Override public M newModule() {


### PR DESCRIPTION
fixes issue #261.  `Provides.Type.SET_VALUES` allows default or additional contributions to Set bindings.  Particularly, it allows you to specify an empty set binding without requiring downstream modules declare `Module.overrides=true`

[Example](https://github.com/adriancole/dagger/blob/provides-setvalues/compiler/src/it/extension-graph-setvalues/src/main/java/test/TestApp.java)

``` java

class TestApp implements Runnable {
  @Inject Set<String> strings;

  @Override public void run() {
    System.out.println(strings);
  }

  public static void main(String[] args) {
    ObjectGraph root = ObjectGraph.create(new RootModule());
    ObjectGraph extension = root.plus(new ExtensionModule());
    extension.get(TestApp.class).run();
  }

  @Module(injects = TestApp.class)
  static class RootModule {
    @Provides(type = SET_VALUES) Set<String> defaultToEmpty(){
      return new HashSet<String>();
    }
  }

  @Module(addsTo=RootModule.class, injects = TestApp.class)
  static class ExtensionModule {
    @Provides(type = SET) String addToSet(){
      return "contributed";
    }
  }
}
```
