### PR TITLE
Added codegen to handle supertypes

### DIFF
--- a/compiler/src/it/abstract-parent-with-injected-members/pom.xml
+++ b/compiler/src/it/abstract-parent-with-injected-members/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (C) 2012 Square, Inc.
+ Copyright (C) 2012 Google, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>abstract-parent-with-injected-members</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <name>Dagger Integration Test Basic</name>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/abstract-parent-with-injected-members/src/main/java/test/TestApp.java
+++ b/compiler/src/it/abstract-parent-with-injected-members/src/main/java/test/TestApp.java
@@ -18,19 +18,22 @@ package test;
 import dagger.Module;
 import dagger.Provides;
 import javax.inject.Inject;
+import test.parentpackage.AbstractParentWithInjectedMember;
 
 class TestApp {
-  static class NotInjectable {
+   
+  static class InjectableSubclass extends AbstractParentWithInjectedMember {
+     @Inject String string;
   }
 
-  static class InjectableSubclass extends NotInjectable {
-    @Inject String string;
-  }
-
-  @Module(injects = InjectableSubclass.class)
+  @Module(injects = {InjectableSubclass.class})
   static class TestModule {
     @Provides String provideString() {
       return "string";
+    }
+    
+    @Provides Integer provideInteger() {
+      return 5;
     }
   }
 }

--- a/compiler/src/it/abstract-parent-with-injected-members/src/main/java/test/parentpackage/AbstractParentWithInjectedMember.java
+++ b/compiler/src/it/abstract-parent-with-injected-members/src/main/java/test/parentpackage/AbstractParentWithInjectedMember.java
@@ -1,0 +1,7 @@
+package test.parentpackage;
+
+import javax.inject.Inject;
+
+public abstract class AbstractParentWithInjectedMember {
+  @Inject Integer integer;
+}

--- a/compiler/src/it/abstract-parent-with-injected-members/verify.bsh
+++ b/compiler/src/it/abstract-parent-with-injected-members/verify.bsh
@@ -1,0 +1,23 @@
+import java.io.File;
+
+File classes = new File(basedir, "target/classes/test/");
+
+File moduleAdapter = new File(classes, "TestApp$TestModule$$ModuleAdapter.class");
+if (!moduleAdapter.exists()) throw new Exception("No binding generated for module");
+
+File integerBinding = 
+    new File(classes, "TestApp$TestModule$$ModuleAdapter$ProvideIntegerProvidesAdapter.class");
+if (!integerBinding.exists()) throw new Exception("No binding generated for integer()");
+
+File stringBinding =
+    new File(classes, "TestApp$TestModule$$ModuleAdapter$ProvideStringProvidesAdapter.class");
+if (!stringBinding.exists()) throw new Exception("No binding generated for string()");
+
+File injectAdapter = new File(classes, "TestApp$InjectableSubclass$$InjectAdapter.class");
+if (!injectAdapter.exists()) 
+  throw new Exception("No inject adapter generated for InjectableSubclass");
+
+File parentAdapter = 
+    new File(classes, "parentpackage/AbstractParentWithInjectedMember$$ParentAdapter$$test_TestApp$InjectableSubclass.class");
+if (!parentAdapter.exists()) 
+  throw new Exception("No parent adapter generated for AbstractParentWithInjectedMember");

--- a/compiler/src/it/grandparent-with-injected-members/pom.xml
+++ b/compiler/src/it/grandparent-with-injected-members/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (C) 2012 Square, Inc.
+ Copyright (C) 2012 Google, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>grandparent-with-injected-members</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <name>Dagger Integration Test Basic</name>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/grandparent-with-injected-members/src/main/java/test/TestApp.java
+++ b/compiler/src/it/grandparent-with-injected-members/src/main/java/test/TestApp.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.Module;
+import dagger.Provides;
+import javax.inject.Inject;
+import test.parentpackage.ParentWithNoInjectedMembers;
+
+class TestApp {
+   
+  static class InjectableSubclass extends ParentWithNoInjectedMembers {
+     @Inject String string;
+  }
+
+  @Module(injects = {InjectableSubclass.class})
+  static class TestModule {
+    @Provides String provideString() {
+      return "string";
+    }
+    
+    @Provides Integer provideInteger() {
+      return 5;
+    }
+  }
+}

--- a/compiler/src/it/grandparent-with-injected-members/src/main/java/test/grandparentpackage/GrandparentWithInjectedMember.java
+++ b/compiler/src/it/grandparent-with-injected-members/src/main/java/test/grandparentpackage/GrandparentWithInjectedMember.java
@@ -1,0 +1,7 @@
+package test.grandparentpackage;
+
+import javax.inject.Inject;
+
+public class GrandparentWithInjectedMember {
+  @Inject Integer integer;
+}

--- a/compiler/src/it/grandparent-with-injected-members/src/main/java/test/parentpackage/ParentWithNoInjectedMembers.java
+++ b/compiler/src/it/grandparent-with-injected-members/src/main/java/test/parentpackage/ParentWithNoInjectedMembers.java
@@ -1,0 +1,6 @@
+package test.parentpackage;
+
+import test.grandparentpackage.GrandparentWithInjectedMember;
+
+public class ParentWithNoInjectedMembers extends GrandparentWithInjectedMember {
+}

--- a/compiler/src/it/grandparent-with-injected-members/verify.bsh
+++ b/compiler/src/it/grandparent-with-injected-members/verify.bsh
@@ -1,0 +1,28 @@
+import java.io.File;
+
+File classes = new File(basedir, "target/classes/test/");
+
+File moduleAdapter = new File(classes, "TestApp$TestModule$$ModuleAdapter.class");
+if (!moduleAdapter.exists()) throw new Exception("No binding generated for module");
+
+File integerBinding = 
+    new File(classes, "TestApp$TestModule$$ModuleAdapter$ProvideIntegerProvidesAdapter.class");
+if (!integerBinding.exists()) throw new Exception("No binding generated for integer()");
+
+File stringBinding =
+    new File(classes, "TestApp$TestModule$$ModuleAdapter$ProvideStringProvidesAdapter.class");
+if (!stringBinding.exists()) throw new Exception("No binding generated for string()");
+
+File injectAdapter = new File(classes, "TestApp$InjectableSubclass$$InjectAdapter.class");
+if (!injectAdapter.exists()) 
+  throw new Exception("No inject adapter generated for InjectableSubclass");
+
+File parentAdapter = 
+    new File(classes, "parentpackage/ParentWithNoInjectedMembers$$ParentAdapter$$test_TestApp$InjectableSubclass.class");
+if (parentAdapter.exists()) 
+  throw new Exception("An unnecessary parent adapter was generated for ParentwithNoInjectedMembers.");
+    
+File grandparentAdapter = 
+    new File(classes, "grandparentpackage/GrandparentWithInjectedMember$$ParentAdapter$$test_TestApp$InjectableSubclass.class");
+if (!grandparentAdapter.exists()) 
+  throw new Exception("No parent adapter was generated for GrandparentwithInjectedMember.");

--- a/compiler/src/it/parent-with-injected-members/pom.xml
+++ b/compiler/src/it/parent-with-injected-members/pom.xml
@@ -21,7 +21,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example.dagger.tests</groupId>
-  <artifactId>uninjectable-supertype</artifactId>
+  <artifactId>parent-with-injected-members</artifactId>
   <version>HEAD-SNAPSHOT</version>
   <name>Dagger Integration Test Basic</name>
   <dependencies>

--- a/compiler/src/it/parent-with-injected-members/src/main/java/test/TestApp.java
+++ b/compiler/src/it/parent-with-injected-members/src/main/java/test/TestApp.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.Module;
+import dagger.Provides;
+import javax.inject.Inject;
+import test.parentpackage.ParentWithInjectedMember;
+
+class TestApp {
+   
+  static class InjectableSubclass extends ParentWithInjectedMember {
+     @Inject String string;
+  }
+
+  @Module(injects = {InjectableSubclass.class})
+  static class TestModule {
+    @Provides String provideString() {
+      return "string";
+    }
+    
+    @Provides Integer provideInteger() {
+      return 5;
+    }
+  }
+}

--- a/compiler/src/it/parent-with-injected-members/src/main/java/test/grandparentpackage/GrandparentWithNoInjectedMembers.java
+++ b/compiler/src/it/parent-with-injected-members/src/main/java/test/grandparentpackage/GrandparentWithNoInjectedMembers.java
@@ -1,0 +1,4 @@
+package test.grandparentpackage;
+
+public class GrandparentWithNoInjectedMembers {
+}

--- a/compiler/src/it/parent-with-injected-members/src/main/java/test/parentpackage/ParentWithInjectedMember.java
+++ b/compiler/src/it/parent-with-injected-members/src/main/java/test/parentpackage/ParentWithInjectedMember.java
@@ -1,0 +1,8 @@
+package test.parentpackage;
+
+import javax.inject.Inject;
+import test.grandparentpackage.GrandparentWithNoInjectedMembers;
+
+public class ParentWithInjectedMember extends GrandparentWithNoInjectedMembers {
+  @Inject Integer integer;
+}

--- a/compiler/src/it/parent-with-injected-members/verify.bsh
+++ b/compiler/src/it/parent-with-injected-members/verify.bsh
@@ -1,0 +1,28 @@
+import java.io.File;
+
+File classes = new File(basedir, "target/classes/test/");
+
+File moduleAdapter = new File(classes, "TestApp$TestModule$$ModuleAdapter.class");
+if (!moduleAdapter.exists()) throw new Exception("No binding generated for module");
+
+File integerBinding = 
+    new File(classes, "TestApp$TestModule$$ModuleAdapter$ProvideIntegerProvidesAdapter.class");
+if (!integerBinding.exists()) throw new Exception("No binding generated for integer()");
+
+File stringBinding =
+    new File(classes, "TestApp$TestModule$$ModuleAdapter$ProvideStringProvidesAdapter.class");
+if (!stringBinding.exists()) throw new Exception("No binding generated for string()");
+
+File injectAdapter = new File(classes, "TestApp$InjectableSubclass$$InjectAdapter.class");
+if (!injectAdapter.exists()) 
+  throw new Exception("No inject adapter generated for InjectableSubclass");
+
+File parentAdapter = 
+    new File(classes, "parentpackage/ParentWithInjectedMember$$ParentAdapter$$test_TestApp$InjectableSubclass.class");
+if (!parentAdapter.exists()) 
+  throw new Exception("No parent adapter generated for ParentWithInjectedMember");
+  
+File grandparentAdapter = 
+    new File(classes, "grandparentpackage/GrandparentWithNoInjectedMembers$$ParentAdapter$$test_TestApp$InjectableSubclass.class");
+if (grandparentAdapter.exists()) 
+  throw new Exception("An unnecessary parent adapter was generated for GrandparentwithNoInjectedMembers.");

--- a/compiler/src/main/java/dagger/internal/codegen/AdapterJavadocs.java
+++ b/compiler/src/main/java/dagger/internal/codegen/AdapterJavadocs.java
@@ -43,9 +43,9 @@ public final class AdapterJavadocs {
       + "A manager for {@code %s}'s injections into static fields.";
 
   /** Creates an appropriate javadoc depending on aspects of the type in question. */
-  static String binderTypeDocs(String type, boolean abstrakt, boolean members, boolean dependent) {
+  static String bindingTypeDocs(String type, boolean abstrakt, boolean members, boolean dependent) {
     StringBuffer sb = new StringBuffer();
-    sb.append("A {@code Binder<").append(type).append(">} implementation which satisfies\n");
+    sb.append("A {@code Binding<").append(type).append(">} implementation which satisfies\n");
     sb.append("Dagger's infrastructure requirements including:");
     if (dependent) {
       sb.append("\n\n");
@@ -65,4 +65,10 @@ public final class AdapterJavadocs {
     return sb.toString();
   }
 
+  static String parentAdapterTypeDocs(String child, String ancestor) {
+    String pattern = "An implementation of {@code MembersInjector<%s>}, used to\n"
+        + "inject the inherited members of {@code %s} when injecting\n"
+        + "instances of its descendant, {@code %s}.";
+    return String.format(pattern, ancestor, ancestor, child);
+  }
 }

--- a/compiler/src/main/java/dagger/internal/codegen/ModuleAdapterProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/ModuleAdapterProcessor.java
@@ -53,7 +53,7 @@ import javax.tools.JavaFileObject;
 
 import static dagger.Provides.Type.SET;
 import static dagger.Provides.Type.SET_VALUES;
-import static dagger.internal.codegen.AdapterJavadocs.binderTypeDocs;
+import static dagger.internal.codegen.AdapterJavadocs.bindingTypeDocs;
 import static dagger.internal.codegen.TypeUtils.adapterName;
 import static dagger.internal.codegen.TypeUtils.getAnnotation;
 import static dagger.internal.codegen.TypeUtils.getNoArgsConstructor;
@@ -415,7 +415,7 @@ public final class ModuleAdapterProcessor extends AbstractProcessor {
     boolean dependent = !parameters.isEmpty();
 
     writer.emitEmptyLine();
-    writer.emitJavadoc(binderTypeDocs(returnType, false, false, dependent));
+    writer.emitJavadoc(bindingTypeDocs(returnType, false, false, dependent));
     writer.beginType(className, "class", PUBLIC | FINAL | STATIC,
         JavaWriter.type(Binding.class, returnType),
         JavaWriter.type(Provider.class, returnType));

--- a/core/src/main/java/dagger/internal/loaders/GeneratedAdapters.java
+++ b/core/src/main/java/dagger/internal/loaders/GeneratedAdapters.java
@@ -23,6 +23,7 @@ package dagger.internal.loaders;
 public final class GeneratedAdapters {
   private static final String SEPARATOR = "$$";
   public static final String INJECT_ADAPTER_SUFFIX = SEPARATOR + "InjectAdapter";
+  public static final String PARENT_ADAPTER_INFIX = SEPARATOR + "ParentAdapter" + SEPARATOR;
   public static final String MODULE_ADAPTER_SUFFIX = SEPARATOR + "ModuleAdapter";
   public static final String STATIC_INJECTION_SUFFIX = SEPARATOR + "StaticInjection";
 

--- a/core/src/test/java/dagger/internal/FailoverLoaderTest.java
+++ b/core/src/test/java/dagger/internal/FailoverLoaderTest.java
@@ -27,8 +27,8 @@ import org.junit.runners.JUnit4;
 import static org.fest.assertions.Assertions.assertThat;
 
 /**
- * A test case to deal with fall-back to reflection where the concrete type has been generated
- * but the parent has no {@code @Inject} annotation, and so has not been generated.
+ * A test case to deal with fall-back to reflection where an inject adapter has not
+ * been generated.
  */
 @RunWith(JUnit4.class)
 public final class FailoverLoaderTest {


### PR DESCRIPTION
This eliminates the need to fall back to reflection when an injected type has a (non platform) supertype. Previously, if a class had a supertype, we would fall back to reflection unless the supertype had an @Inject annotation. In fact, in order to not fall back to reflection, every (non-platform) ancestor would have to have an @Inject annotation. 

This change is particularly relevant to classes with abstract supertypes that do not have members injection. The abstract supertype would have no @Inject annotation, and in its current state, Dagger would fall back to reflection.

Also note that the ParentAdapters that are generated only implement MembersInjector. That is, they are not Bindings since all we need them for is to do members injection in the parents. Additionally, we only create parent adapters when needed. So, if a class has some ancestors that have members injection and some that do not, adapters will only be generated for those that do.

This _is_ a change in behavior, and its only downside is that Dagger will no longer automatically detect if somebody swaps in a parent type from an upstream dependency without recompiling. 
