### PR TITLE
Added new static checks

### DIFF
--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -79,6 +79,7 @@
             <goals><goal>testCompile</goal></goals>
             <configuration>
               <annotationProcessors>
+                <annotationProcessor>dagger.internal.codegen.ValidationProcessor</annotationProcessor>
                 <annotationProcessor>dagger.internal.codegen.InjectAdapterProcessor</annotationProcessor>
                 <annotationProcessor>dagger.internal.codegen.ModuleAdapterProcessor</annotationProcessor>
                 <annotationProcessor>dagger.internal.codegen.GraphAnalysisProcessor</annotationProcessor>

--- a/compiler/src/it/final-field-inject/invoker.properties
+++ b/compiler/src/it/final-field-inject/invoker.properties
@@ -1,0 +1,1 @@
+invoker.buildResult=failure

--- a/compiler/src/it/final-field-inject/pom.xml
+++ b/compiler/src/it/final-field-inject/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2013 Google, Inc.
+  Copyright (C) 2013 Square, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>final-field-inject</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/final-field-inject/src/main/java/test/TestApp.java
+++ b/compiler/src/it/final-field-inject/src/main/java/test/TestApp.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import javax.inject.Inject;
+
+class TestApp {
+  @Inject final Object nope;
+}

--- a/compiler/src/it/final-field-inject/verify.bsh
+++ b/compiler/src/it/final-field-inject/verify.bsh
@@ -1,0 +1,6 @@
+import dagger.testing.it.BuildLogValidator;
+import java.io.File;
+
+File buildLog = new File(basedir, "build.log");
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Can't inject a final field: test.TestApp.nope"});

--- a/compiler/src/it/multiple-qualifiers/invoker.properties
+++ b/compiler/src/it/multiple-qualifiers/invoker.properties
@@ -1,0 +1,1 @@
+invoker.buildResult=failure

--- a/compiler/src/it/multiple-qualifiers/pom.xml
+++ b/compiler/src/it/multiple-qualifiers/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2013 Google, Inc.
+  Copyright (C) 2013 Square, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>multiple-qualifiers</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/multiple-qualifiers/src/main/java/test/TestApp.java
+++ b/compiler/src/it/multiple-qualifiers/src/main/java/test/TestApp.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.Module;
+import dagger.Provides;
+import java.lang.annotation.Retention;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.inject.Qualifier;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+class TestApp {
+  static class TestClass1 {
+    @Inject
+    @MyQualifier1
+    @MyQualifier2
+    String field;
+  }
+
+  static class TestClass2 {
+    String string;
+
+    public TestClass2(@MyQualifier1 @MyQualifier2 String constructorParam) {
+      this.string = string;
+    }
+  }
+
+  @Module(injects = TestClass1.class)
+  static class TestModule {
+    @MyQualifier1
+    @MyQualifier2
+    @Provides
+    String providesString() {
+      return "string";
+    }
+  }
+ 
+  @Qualifier
+  @Retention(value = RUNTIME)
+  @interface MyQualifier1 {}
+ 
+  @Qualifier
+  @Retention(value = RUNTIME)
+  @interface MyQualifier2 {}
+}

--- a/compiler/src/it/multiple-qualifiers/verify.bsh
+++ b/compiler/src/it/multiple-qualifiers/verify.bsh
@@ -1,0 +1,10 @@
+import dagger.testing.it.BuildLogValidator;
+import java.io.File;
+
+File buildLog = new File(basedir, "build.log");
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Only one qualifier annotation is allowed per element: test.TestApp.TestClass1.field"});
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Only one qualifier annotation is allowed per element: constructorParam"});   
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Only one qualifier annotation is allowed per element: test.TestApp.TestModule.providesString()"});

--- a/compiler/src/it/multiple-scopes/invoker.properties
+++ b/compiler/src/it/multiple-scopes/invoker.properties
@@ -1,0 +1,1 @@
+invoker.buildResult=failure

--- a/compiler/src/it/multiple-scopes/pom.xml
+++ b/compiler/src/it/multiple-scopes/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2013 Google, Inc.
+  Copyright (C) 2013 Square, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>multiple-scopes</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/multiple-scopes/src/main/java/test/TestApp.java
+++ b/compiler/src/it/multiple-scopes/src/main/java/test/TestApp.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.Module;
+import dagger.Provides;
+import java.lang.annotation.Retention;
+import javax.inject.Inject;
+import javax.inject.Scope;
+import javax.inject.Singleton;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;;
+
+class TestApp {
+
+  @Singleton
+  @CustomScope
+  static class InjectableClass {
+    @Inject
+    String string;
+  }
+
+  @Module(injects = InjectableClass.class)
+  static class TestModule {
+    @Singleton
+    @CustomScope
+    @Provides
+    String string() {
+      return "string";
+    }
+  }
+
+  @Scope
+  @Retention(value = RUNTIME)
+  public @interface CustomScope {
+  }
+}

--- a/compiler/src/it/multiple-scopes/verify.bsh
+++ b/compiler/src/it/multiple-scopes/verify.bsh
@@ -1,0 +1,8 @@
+import dagger.testing.it.BuildLogValidator;
+import java.io.File;
+
+File buildLog = new File(basedir, "build.log");
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Only one scoping annotation is allowed per element: test.TestApp.InjectableClass"});
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Only one scoping annotation is allowed per element: test.TestApp.TestModule.string()"});

--- a/compiler/src/it/private-inject/verify.bsh
+++ b/compiler/src/it/private-inject/verify.bsh
@@ -3,6 +3,6 @@ import java.io.File;
 
 File buildLog = new File(basedir, "build.log");
 new BuildLogValidator().assertHasText(buildLog, new String[]{
-    "Can't inject a private field or constructor: test.TestApp.nope"});
+    "Can't inject a private field: test.TestApp.nope"});
 new BuildLogValidator().assertHasText(buildLog, new String[]{
-    "Can't inject a private field or constructor: test.TestFoo.TestFoo()"});
+    "Can't inject a private constructor: test.TestFoo.TestFoo()"});

--- a/compiler/src/it/provides-method-not-in-module/invoker.properties
+++ b/compiler/src/it/provides-method-not-in-module/invoker.properties
@@ -1,0 +1,1 @@
+invoker.buildResult=failure

--- a/compiler/src/it/provides-method-not-in-module/pom.xml
+++ b/compiler/src/it/provides-method-not-in-module/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2013 Google, Inc.
+  Copyright (C) 2013 Square, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>provides-method-not-in-module</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/provides-method-not-in-module/src/main/java/test/TestApp.java
+++ b/compiler/src/it/provides-method-not-in-module/src/main/java/test/TestApp.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.Provides;
+
+class TestApp {
+
+  @Provides
+  String providesString() {
+    return "string";
+  }
+}

--- a/compiler/src/it/provides-method-not-in-module/verify.bsh
+++ b/compiler/src/it/provides-method-not-in-module/verify.bsh
@@ -1,0 +1,6 @@
+import dagger.testing.it.BuildLogValidator;
+import java.io.File;
+
+File buildLog = new File(basedir, "build.log");
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "@Provides methods must be declared in modules: test.TestApp.providesString()"});

--- a/compiler/src/it/qualifiers-on-invalid-elements-errors/invoker.properties
+++ b/compiler/src/it/qualifiers-on-invalid-elements-errors/invoker.properties
@@ -1,0 +1,1 @@
+invoker.buildResult=failure

--- a/compiler/src/it/qualifiers-on-invalid-elements-errors/pom.xml
+++ b/compiler/src/it/qualifiers-on-invalid-elements-errors/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2013 Google, Inc.
+  Copyright (C) 2013 Square, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>qualifiers-on-invalid-elements-errors</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+          <showWarnings>true</showWarnings>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/qualifiers-on-invalid-elements-errors/src/main/java/test/TestApp.java
+++ b/compiler/src/it/qualifiers-on-invalid-elements-errors/src/main/java/test/TestApp.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.Module;
+import dagger.Provides;
+import java.lang.annotation.Retention;
+import javax.inject.Inject;
+import javax.inject.Qualifier;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+class TestApp {
+
+  @MyQualifier
+  static class TestClass1 {
+    
+    @MyQualifier // qualfier on non-injectable constructor
+    public TestClass1(String constructorParam) {}
+  }
+  
+  static class TestClass2 {
+    String string;
+    
+    @Inject
+    @MyQualifier // qualifier on injectable constructor
+    public TestClass2(String injectableConstructorParam) {
+      this.string = string;
+    }  
+  }
+  
+  @Qualifier
+  @Retention(value = RUNTIME)
+  @interface MyQualifier {}
+}

--- a/compiler/src/it/qualifiers-on-invalid-elements-errors/verify.bsh
+++ b/compiler/src/it/qualifiers-on-invalid-elements-errors/verify.bsh
@@ -1,0 +1,10 @@
+import dagger.testing.it.BuildLogValidator;
+import java.io.File;
+
+File buildLog = new File(basedir, "build.log");
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Qualifier annotations are only allowed on fields, methods, and parameters: test.TestApp.TestClass1"});   
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Qualifier annotations are only allowed on fields, methods, and parameters: test.TestApp.TestClass1.TestClass1(java.lang.String)"});   
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Qualifier annotations are only allowed on fields, methods, and parameters: test.TestApp.TestClass2.TestClass2(java.lang.String)"});

--- a/compiler/src/it/qualifiers-on-invalid-elements-warnings/pom.xml
+++ b/compiler/src/it/qualifiers-on-invalid-elements-warnings/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2013 Google, Inc.
+  Copyright (C) 2013 Square, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>qualifiers-on-invalid-elements-warnings</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+          <showWarnings>true</showWarnings>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/qualifiers-on-invalid-elements-warnings/src/main/java/test/TestApp.java
+++ b/compiler/src/it/qualifiers-on-invalid-elements-warnings/src/main/java/test/TestApp.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.Module;
+import dagger.Provides;
+import java.lang.annotation.Retention;
+import javax.inject.Inject;
+import javax.inject.Qualifier;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+class TestApp {
+
+  static class TestClass {
+    @MyQualifier int field1; // non-injectable field
+    
+    @SuppressWarnings("some string other than 'qualifiers'")
+    @MyQualifier 
+    int field2;
+    
+    @SuppressWarnings("qualifiers")
+    @MyQualifier 
+    int fieldWithWarningSuppressed1;
+    
+    @SuppressWarnings({"foo", "qualifiers", "bar"})
+    @MyQualifier 
+    int fieldWithWarningSuppressed2;
+    
+    // qualfier on non-injectable constructor parameter
+    public TestClass(@MyQualifier String constructorParam) {}
+    
+    @MyQualifier 
+    void nonProvidesMethod(@MyQualifier String methodParam) {}
+  }
+  
+  @Qualifier
+  @Retention(value = RUNTIME)
+  @interface MyQualifier {}
+}

--- a/compiler/src/it/qualifiers-on-invalid-elements-warnings/verify.bsh
+++ b/compiler/src/it/qualifiers-on-invalid-elements-warnings/verify.bsh
@@ -1,0 +1,18 @@
+import dagger.testing.it.BuildLogValidator;
+import java.io.File;
+
+File buildLog = new File(basedir, "build.log");
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Dagger will ignore qualifier annotations on fields that are not annotated with @Inject: test.TestApp.TestClass.field1"});   
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Dagger will ignore qualifier annotations on fields that are not annotated with @Inject: test.TestApp.TestClass.field2"});   
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Dagger will ignore qualifier annotations on methods that are not @Provides methods: test.TestApp.TestClass.nonProvidesMethod(java.lang.String)"});  
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Dagger will ignore qualifier annotations on parameters that are not @Inject constructor parameters or @Provides method parameters: methodParam"});  
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Dagger will ignore qualifier annotations on parameters that are not @Inject constructor parameters or @Provides method parameters: constructorParam"});
+new BuildLogValidator().assertDoesNotHaveText(buildLog, new String[]{
+    "Dagger will ignore qualifier annotations on fields that are not annotated with @Inject: test.TestApp.TestClass.fieldWithWarningSuppressed1"});
+new BuildLogValidator().assertDoesNotHaveText(buildLog, new String[]{
+    "Dagger will ignore qualifier annotations on fields that are not annotated with @Inject: test.TestApp.TestClass.fieldWithWarningSuppressed2"});

--- a/compiler/src/it/scope-on-abstract/invoker.properties
+++ b/compiler/src/it/scope-on-abstract/invoker.properties
@@ -1,0 +1,1 @@
+invoker.buildResult=failure

--- a/compiler/src/it/scope-on-abstract/pom.xml
+++ b/compiler/src/it/scope-on-abstract/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2013 Google, Inc.
+  Copyright (C) 2013 Square, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>scope-on-abstract</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/scope-on-abstract/src/main/java/test/TestApp.java
+++ b/compiler/src/it/scope-on-abstract/src/main/java/test/TestApp.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import javax.inject.Singleton;
+
+class TestApp {
+  
+  @Singleton
+  abstract class AbstractClass {}
+
+  @Singleton
+  interface Interface {}
+}

--- a/compiler/src/it/scope-on-abstract/verify.bsh
+++ b/compiler/src/it/scope-on-abstract/verify.bsh
@@ -1,0 +1,8 @@
+import dagger.testing.it.BuildLogValidator;
+import java.io.File;
+
+File buildLog = new File(basedir, "build.log");
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Scoping annotations are only allowed on concrete types and @Provides methods: test.TestApp.AbstractClass"});
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Scoping annotations are only allowed on concrete types and @Provides methods: test.TestApp.Interface"});

--- a/compiler/src/it/scopes-on-invalid-elements-errors/invoker.properties
+++ b/compiler/src/it/scopes-on-invalid-elements-errors/invoker.properties
@@ -1,0 +1,1 @@
+invoker.buildResult=failure

--- a/compiler/src/it/scopes-on-invalid-elements-errors/pom.xml
+++ b/compiler/src/it/scopes-on-invalid-elements-errors/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2013 Google, Inc.
+  Copyright (C) 2013 Square, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>scopes-on-invalid-elements-errors</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/scopes-on-invalid-elements-errors/src/main/java/test/TestApp.java
+++ b/compiler/src/it/scopes-on-invalid-elements-errors/src/main/java/test/TestApp.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.Module;
+import dagger.Provides;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+class TestApp {
+
+  static class TestClass1 {
+    // Scoped Injectable field
+    @Inject
+    @Singleton
+    Integer field;
+
+    // method with a scoped parameter
+    void method(@Singleton int param) {}
+  }
+
+  static class TestClass2 {
+    // Scoped non-injectable field
+    @Singleton
+    String string;
+  }
+
+  @Module(complete = false, library = true)
+  static class TestModule {
+    
+    // Even though it's a @Provides method, its parameters cannot be scoped
+    @Provides
+    Integer integer(@Singleton int myInt) {
+      return myInt;
+    }
+  }
+}

--- a/compiler/src/it/scopes-on-invalid-elements-errors/verify.bsh
+++ b/compiler/src/it/scopes-on-invalid-elements-errors/verify.bsh
@@ -1,0 +1,12 @@
+import dagger.testing.it.BuildLogValidator;
+import java.io.File;
+
+File buildLog = new File(basedir, "build.log");
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Scoping annotations are only allowed on concrete types and @Provides methods: test.TestApp.TestClass1.field"});   
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Scoping annotations are only allowed on concrete types and @Provides methods: param"});   
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Scoping annotations are only allowed on concrete types and @Provides methods: test.TestApp.TestClass2.string"});   
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Scoping annotations are only allowed on concrete types and @Provides methods: myInt"});

--- a/compiler/src/it/scopes-on-invalid-elements-warnings/pom.xml
+++ b/compiler/src/it/scopes-on-invalid-elements-warnings/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2013 Google, Inc.
+  Copyright (C) 2013 Square, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>scopes-on-invalid-elements-warnings</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+         <showWarnings>true</showWarnings>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/scopes-on-invalid-elements-warnings/src/main/java/test/TestApp.java
+++ b/compiler/src/it/scopes-on-invalid-elements-warnings/src/main/java/test/TestApp.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import javax.inject.Singleton;
+
+class TestApp {
+   
+    // Scoped non @Provides method
+    @Singleton
+    void method1() {}
+    
+    @SuppressWarnings("some string other than 'scoping'")
+    @Singleton
+    void method2() {}
+    
+    @SuppressWarnings("scoping")
+    @Singleton
+    void methodWithWarningSupressed1() {}
+    
+    @SuppressWarnings({"foo", "scoping", "bar"})
+    @Singleton
+    void methodWithWarningSupressed2() {}
+}

--- a/compiler/src/it/scopes-on-invalid-elements-warnings/verify.bsh
+++ b/compiler/src/it/scopes-on-invalid-elements-warnings/verify.bsh
@@ -1,0 +1,12 @@
+import dagger.testing.it.BuildLogValidator;
+import java.io.File;
+
+File buildLog = new File(basedir, "build.log");
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Dagger will ignore scoping annotations on methods that are not @Provides methods: test.TestApp.method1()"});
+new BuildLogValidator().assertHasText(buildLog, new String[]{
+    "Dagger will ignore scoping annotations on methods that are not @Provides methods: test.TestApp.method2()"});
+new BuildLogValidator().assertDoesNotHaveText(buildLog, new String[]{
+    "Dagger will ignore scoping annotations on methods that are not @Provides methods: test.TestApp.methodWithWarningSupressed1()"});
+new BuildLogValidator().assertDoesNotHaveText(buildLog, new String[]{
+    "Dagger will ignore scoping annotations on methods that are not @Provides methods: test.TestApp.methodWithWarningSupressed2()"});

--- a/compiler/src/it/valid-scoping/pom.xml
+++ b/compiler/src/it/valid-scoping/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (C) 2013 Google, Inc.
+ Copyright (C) 2013 Square, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>valid-scoping</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <name>Dagger Integration Test Basic</name>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/valid-scoping/src/main/java/test/TestApp.java
+++ b/compiler/src/it/valid-scoping/src/main/java/test/TestApp.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.Module;
+import dagger.Provides;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+class TestApp {
+  
+  @Singleton
+  static class InjectableClass {
+    @Inject String string;
+  }
+
+  @Module(injects = InjectableClass.class)
+  static class TestModule {
+    
+    @Singleton
+    @Provides 
+    String string() {
+      return "string";
+    }
+  }
+}

--- a/compiler/src/it/valid-use-of-qualifiers/pom.xml
+++ b/compiler/src/it/valid-use-of-qualifiers/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (C) 2013 Google, Inc.
+ Copyright (C) 2013 Square, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>valid-use-ofqualifiers</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <name>Dagger Integration Test Basic</name>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+          <showWarnings>true</showWarnings>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/valid-use-of-qualifiers/src/main/java/test/TestApp.java
+++ b/compiler/src/it/valid-use-of-qualifiers/src/main/java/test/TestApp.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.Module;
+import dagger.Provides;
+import java.lang.annotation.Retention;
+import javax.inject.Inject;
+import javax.inject.Qualifier;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+class TestApp {
+  static class TestClass1 {
+    @Inject @MyQualifier1 String field;
+  }
+  
+  static class TestClass2 {
+    String string;
+    
+    @Inject
+    public TestClass2(@MyQualifier1 String constructorParam) {
+      this.string = string;
+    }
+  }
+
+  @Module(injects = TestClass1.class)
+  static class TestModule {
+
+    @Provides
+    @MyQualifier1
+    String providesString(@MyQualifier2 String providesMethodParam) {
+      return providesMethodParam + "foo";
+    }
+    
+    @Provides
+    @MyQualifier2
+    String providesString() {
+      return "foo";
+    }
+  }
+  @Qualifier
+  @Retention(value = RUNTIME)
+  @interface MyQualifier1 {}
+  
+  @Qualifier
+  @Retention(value = RUNTIME)
+  @interface MyQualifier2 {}
+}

--- a/compiler/src/main/java/dagger/internal/codegen/GeneratorKeys.java
+++ b/compiler/src/main/java/dagger/internal/codegen/GeneratorKeys.java
@@ -25,8 +25,8 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 
-import static dagger.internal.codegen.TypeUtils.rawTypeToString;
-import static dagger.internal.codegen.TypeUtils.typeToString;
+import static dagger.internal.codegen.Util.rawTypeToString;
+import static dagger.internal.codegen.Util.typeToString;
 
 /**
  * Creates keys using javac's mirror APIs. Unlike {@code Keys}, this class uses
@@ -57,7 +57,7 @@ final class GeneratorKeys {
   /** Returns the provided key for {@code method}. */
   public static String get(ExecutableElement method) {
     StringBuilder result = new StringBuilder();
-    AnnotationMirror qualifier = getQualifier(method.getAnnotationMirrors(), method);
+    AnnotationMirror qualifier = getQualifier(method.getAnnotationMirrors());
     if (qualifier != null) {
       qualifierToString(qualifier, result);
     }
@@ -68,7 +68,7 @@ final class GeneratorKeys {
   /** Returns the provided key for {@code method} wrapped by {@code Set}. */
   public static String getSetKey(ExecutableElement method) {
     StringBuilder result = new StringBuilder();
-    AnnotationMirror qualifier = getQualifier(method.getAnnotationMirrors(), method);
+    AnnotationMirror qualifier = getQualifier(method.getAnnotationMirrors());
     if (qualifier != null) {
       qualifierToString(qualifier, result);
     }
@@ -81,7 +81,7 @@ final class GeneratorKeys {
   /** Returns the provider key for {@code variable}. */
   public static String get(VariableElement variable) {
     StringBuilder result = new StringBuilder();
-    AnnotationMirror qualifier = getQualifier(variable.getAnnotationMirrors(), variable);
+    AnnotationMirror qualifier = getQualifier(variable.getAnnotationMirrors());
     if (qualifier != null) {
       qualifierToString(qualifier, result);
     }
@@ -103,15 +103,13 @@ final class GeneratorKeys {
     result.append(")/");
   }
 
+  /** Does not test for multiple qualifiers. This is tested in {@code ValidationProcessor}.  */
   private static AnnotationMirror getQualifier(
-      List<? extends AnnotationMirror> annotations, Object member) {
+      List<? extends AnnotationMirror> annotations) {
     AnnotationMirror qualifier = null;
     for (AnnotationMirror annotation : annotations) {
       if (annotation.getAnnotationType().asElement().getAnnotation(Qualifier.class) == null) {
         continue;
-      }
-      if (qualifier != null) {
-        throw new IllegalArgumentException("Too many qualifier annotations on " + member);
       }
       qualifier = annotation;
     }

--- a/compiler/src/main/java/dagger/internal/codegen/GraphAnalysisInjectBinding.java
+++ b/compiler/src/main/java/dagger/internal/codegen/GraphAnalysisInjectBinding.java
@@ -30,7 +30,7 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 
-import static dagger.internal.codegen.TypeUtils.getApplicationSupertype;
+import static dagger.internal.codegen.Util.getApplicationSupertype;
 
 /**
  * A build time binding that injects the constructor and fields of a class.

--- a/compiler/src/main/java/dagger/internal/codegen/GraphAnalysisProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/GraphAnalysisProcessor.java
@@ -53,10 +53,10 @@ import javax.tools.StandardLocation;
 
 import static dagger.Provides.Type.SET;
 import static dagger.Provides.Type.SET_VALUES;
-import static dagger.internal.codegen.TypeUtils.getAnnotation;
-import static dagger.internal.codegen.TypeUtils.getPackage;
-import static dagger.internal.codegen.TypeUtils.isInterface;
-import static dagger.internal.codegen.TypeUtils.methodName;
+import static dagger.internal.codegen.Util.getAnnotation;
+import static dagger.internal.codegen.Util.getPackage;
+import static dagger.internal.codegen.Util.isInterface;
+import static dagger.internal.codegen.Util.methodName;
 
 /**
  * Performs full graph analysis on a module.
@@ -84,7 +84,7 @@ public final class GraphAnalysisProcessor extends AbstractProcessor {
         }
         delayedModuleNames.add(((TypeElement) e).getQualifiedName().toString());
       }
-      return true;
+      return false;
     }
 
     Set<Element> modules = new LinkedHashSet<Element>();
@@ -132,7 +132,7 @@ public final class GraphAnalysisProcessor extends AbstractProcessor {
         }
       }
     }
-    return true;
+    return false;
   }
 
   private void error(String message, Element element) {

--- a/compiler/src/main/java/dagger/internal/codegen/GraphAnalysisStaticInjection.java
+++ b/compiler/src/main/java/dagger/internal/codegen/GraphAnalysisStaticInjection.java
@@ -20,7 +20,7 @@ import dagger.internal.StaticInjection;
 import javax.inject.Inject;
 import javax.lang.model.element.Element;
 
-import static dagger.internal.codegen.TypeUtils.isStatic;
+import static dagger.internal.codegen.Util.isStatic;
 
 public final class GraphAnalysisStaticInjection extends StaticInjection {
 

--- a/compiler/src/main/java/dagger/internal/codegen/ModuleAdapterProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/ModuleAdapterProcessor.java
@@ -55,13 +55,14 @@ import javax.tools.JavaFileObject;
 import static dagger.Provides.Type.SET;
 import static dagger.Provides.Type.SET_VALUES;
 import static dagger.internal.codegen.AdapterJavadocs.binderTypeDocs;
-import static dagger.internal.codegen.TypeUtils.adapterName;
-import static dagger.internal.codegen.TypeUtils.getAnnotation;
-import static dagger.internal.codegen.TypeUtils.getNoArgsConstructor;
-import static dagger.internal.codegen.TypeUtils.getPackage;
-import static dagger.internal.codegen.TypeUtils.isCallableConstructor;
-import static dagger.internal.codegen.TypeUtils.isInterface;
-import static dagger.internal.codegen.TypeUtils.typeToString;
+import static dagger.internal.codegen.Util.adapterName;
+import static dagger.internal.codegen.Util.elementToString;
+import static dagger.internal.codegen.Util.getAnnotation;
+import static dagger.internal.codegen.Util.getNoArgsConstructor;
+import static dagger.internal.codegen.Util.getPackage;
+import static dagger.internal.codegen.Util.isCallableConstructor;
+import static dagger.internal.codegen.Util.isInterface;
+import static dagger.internal.codegen.Util.typeToString;
 import static dagger.internal.loaders.GeneratedAdapters.MODULE_ADAPTER_SUFFIX;
 import static java.lang.reflect.Modifier.FINAL;
 import static java.lang.reflect.Modifier.PRIVATE;
@@ -130,7 +131,7 @@ public final class ModuleAdapterProcessor extends AbstractProcessor {
           break; // valid, move along
         default:
           // TODO(tbroyer): pass annotation information
-          error("Unexpected @Provides on " + providerMethod, providerMethod);
+          error("Unexpected @Provides on " + elementToString(providerMethod), providerMethod);
           continue;
       }
       TypeElement type = (TypeElement) providerMethod.getEnclosingElement();
@@ -185,7 +186,7 @@ public final class ModuleAdapterProcessor extends AbstractProcessor {
     // should still be registered and a ModuleAdapter should still be written.
     for (Element module : env.getElementsAnnotatedWith(Module.class)) {
       if (!module.getKind().equals(ElementKind.CLASS)) {
-        error("Modules must be classes: " + module, module);
+        error("Modules must be classes: " + elementToString(module), module);
         continue;
       }
 
@@ -193,7 +194,7 @@ public final class ModuleAdapterProcessor extends AbstractProcessor {
 
       // Verify that all modules do not extend from non-Object types.
       if (!moduleType.getSuperclass().equals(objectType)) {
-        error("Modules must not extend from other classes: " + module, module);
+        error("Modules must not extend from other classes: " + elementToString(module), module);
       }
 
       String moduleName = moduleType.getQualifiedName().toString();

--- a/compiler/src/main/java/dagger/internal/codegen/Util.java
+++ b/compiler/src/main/java/dagger/internal/codegen/Util.java
@@ -43,8 +43,8 @@ import javax.lang.model.util.SimpleTypeVisitor6;
 /**
  * Utilities for handling types in annotation processors
  */
-final class TypeUtils {
-  private TypeUtils() {
+final class Util {
+  private Util() {
   }
 
   public static PackageElement getPackage(Element type) {
@@ -218,6 +218,20 @@ final class TypeUtils {
       return value instanceof TypeMirror;
     } else {
       return expectedClass == value.getClass();
+    }
+  }
+
+  // TODO(sgoldfed): better format for other types of elements?
+  static String elementToString(Element element) {
+    switch (element.getKind()) {
+      case FIELD:
+      // fall through
+      case CONSTRUCTOR:
+      // fall through
+      case METHOD:
+        return element.getEnclosingElement() + "." + element;
+      default:
+        return element.toString();
     }
   }
 

--- a/compiler/src/main/java/dagger/internal/codegen/ValidationProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/ValidationProcessor.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dagger.internal.codegen;
+
+import dagger.Module;
+import dagger.Provides;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.inject.Inject;
+import javax.inject.Qualifier;
+import javax.inject.Scope;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+
+import static dagger.internal.codegen.Util.elementToString;
+import static javax.lang.model.element.ElementKind.CONSTRUCTOR;
+import static javax.lang.model.element.ElementKind.METHOD;
+import static javax.lang.model.element.Modifier.ABSTRACT;
+
+/**
+ * Checks for errors that are not directly related to modules and
+ *  {@code @Inject} annotated elements.
+ *
+ *  <p> Warnings for invalid use of qualifier annotations can be suppressed
+ *  with @SuppressWarnings("qualifiers")
+ *
+ *  <p> Warnings for invalid use of scoping annotations can be suppressed
+ *  with @SuppressWarnings("scoping")
+ */
+@SupportedAnnotationTypes({ "*" })
+public final class ValidationProcessor extends AbstractProcessor {
+
+  @Override public SourceVersion getSupportedSourceVersion() {
+    return SourceVersion.latestSupported();
+  }
+
+  @Override public boolean process(Set<? extends TypeElement> types, RoundEnvironment env) {
+    List<Element> allElements = new ArrayList<Element>();
+    Map<Element, Element> parametersToTheirMethods = new LinkedHashMap<Element, Element>();
+    getAllElements(env, allElements, parametersToTheirMethods);
+    for (Element element : allElements) {
+        validateProvides(element);
+        validateScoping(element);
+        validateQualifiers(element, parametersToTheirMethods);
+    }
+    return false;
+  }
+
+  private void validateProvides(Element element) {
+    if (element.getAnnotation(Provides.class) != null
+        && element.getEnclosingElement().getAnnotation(Module.class) == null) {
+      error("@Provides methods must be declared in modules: " + elementToString(element), element);
+    }
+  }
+
+  private void validateQualifiers(Element element, Map<Element, Element> parametersToTheirMethods) {
+    boolean suppressWarnings =
+        element.getAnnotation(SuppressWarnings.class) != null && Arrays.asList(
+            element.getAnnotation(SuppressWarnings.class).value()).contains("qualifiers");
+    int numberOfQualifiersOnElement = 0;
+    for (AnnotationMirror annotation : element.getAnnotationMirrors()) {
+      if (annotation.getAnnotationType().asElement().getAnnotation(Qualifier.class) == null) {
+       continue;
+      }
+      switch (element.getKind()) {
+        case FIELD:
+          numberOfQualifiersOnElement++;
+          if (element.getAnnotation(Inject.class) == null && !suppressWarnings) {
+            warning("Dagger will ignore qualifier annotations on fields that are not "
+                + "annotated with @Inject: " + elementToString(element), element);
+          }
+          break;
+        case METHOD:
+          numberOfQualifiersOnElement++;
+          if (!isProvidesMethod(element) && !suppressWarnings) {
+            warning("Dagger will ignore qualifier annotations on methods that are not "
+                + "@Provides methods: " + elementToString(element), element);
+          }
+          break;
+        case PARAMETER:
+          numberOfQualifiersOnElement++;
+          if (!isInjectableConstructorParameter(element, parametersToTheirMethods)
+              && !isProvidesMethodParameter(element, parametersToTheirMethods)
+              && !suppressWarnings) {
+            warning("Dagger will ignore qualifier annotations on parameters that are not "
+                + "@Inject constructor parameters or @Provides method parameters: "
+                + elementToString(element), element);
+          }
+          break;
+        default:
+          error("Qualifier annotations are only allowed on fields, methods, and parameters: "
+              + elementToString(element), element);
+      }
+    }
+    if (numberOfQualifiersOnElement > 1) {
+      error("Only one qualifier annotation is allowed per element: " + elementToString(element),
+          element);
+    }
+  }
+
+  private void validateScoping(Element element) {
+    boolean suppressWarnings =
+        element.getAnnotation(SuppressWarnings.class) != null && Arrays.asList(
+            element.getAnnotation(SuppressWarnings.class).value()).contains("scoping");
+    int numberOfScopingAnnotationsOnElement = 0;
+    for (AnnotationMirror annotation : element.getAnnotationMirrors()) {
+      if (annotation.getAnnotationType().asElement().getAnnotation(Scope.class) == null) {
+        continue;
+      }
+      switch (element.getKind()) {
+        case METHOD:
+          numberOfScopingAnnotationsOnElement++;
+          if (!isProvidesMethod(element) && !suppressWarnings) {
+            warning("Dagger will ignore scoping annotations on methods that are not "
+                + "@Provides methods: " + elementToString(element), element);
+          }
+          break;
+        case CLASS:
+          if (!element.getModifiers().contains(ABSTRACT)) {
+            numberOfScopingAnnotationsOnElement++;
+            break;
+          }
+        // fall through if abstract
+        default:
+          error("Scoping annotations are only allowed on concrete types and @Provides methods: "
+              + elementToString(element), element);
+      }
+    }
+    if (numberOfScopingAnnotationsOnElement > 1) {
+      error("Only one scoping annotation is allowed per element: " + elementToString(element),
+          element);
+    }
+  }
+
+  private void getAllElements(
+      RoundEnvironment env, List<Element> result, Map<Element, Element> parametersToTheirMethods) {
+    for (Element element : env.getRootElements()) {
+      addAllEnclosed(element, result, parametersToTheirMethods);
+    }
+  }
+
+  private void addAllEnclosed(
+      Element element, List<Element> result, Map<Element, Element> parametersToTheirMethods) {
+    result.add(element);
+    for (Element enclosed : element.getEnclosedElements()) {
+      addAllEnclosed(enclosed, result, parametersToTheirMethods);
+      if (enclosed.getKind() == METHOD || enclosed.getKind() == CONSTRUCTOR) {
+        for (Element parameter : ((ExecutableElement) enclosed).getParameters()) {
+          result.add(parameter);
+          parametersToTheirMethods.put(parameter, enclosed);
+        }
+      }
+    }
+  }
+
+  private boolean isProvidesMethod(Element element) {
+    return element.getKind() == METHOD && element.getAnnotation(Provides.class) != null;
+  }
+
+  /**
+   * @param parameter an {@code Element} whose {@code Kind} is parameter. The {@code Kind} is not
+   *        tested here.
+   */
+  private boolean isProvidesMethodParameter(
+      Element parameter, Map<Element, Element> parametersToTheirMethods) {
+    return parametersToTheirMethods.get(parameter).getAnnotation(Provides.class) != null;
+  }
+
+  /**
+   * @param parameter an {@code Element} whose {@code Kind} is parameter. The {@code Kind} is not
+   *        tested here.
+   */
+  private boolean isInjectableConstructorParameter(
+      Element parameter, Map<Element, Element> parametersToTheirMethods) {
+    return parametersToTheirMethods.get(parameter).getKind() == CONSTRUCTOR
+        && parametersToTheirMethods.get(parameter).getAnnotation(Inject.class) != null;
+  }
+
+  private void error(String msg, Element element) {
+    processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, msg, element);
+  }
+
+  private void warning(String msg, Element element) {
+    processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, msg, element);
+  }
+
+}

--- a/compiler/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/compiler/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,3 +1,4 @@
+dagger.internal.codegen.ValidationProcessor
 dagger.internal.codegen.InjectAdapterProcessor
 dagger.internal.codegen.ModuleAdapterProcessor
 dagger.internal.codegen.GraphAnalysisProcessor

--- a/compiler/src/test/java/dagger/internal/codegen/GraphVisualizerTest.java
+++ b/compiler/src/test/java/dagger/internal/codegen/GraphVisualizerTest.java
@@ -36,12 +36,14 @@ public final class GraphVisualizerTest {
     assertThat(graphVisualizer.shortName(key)).isEqualTo("String");
   }
 
+  @SuppressWarnings("qualifiers")
   @Named String annotatedKey;
   @Test public void testAnnotatedKey() throws Exception {
     String key = fieldKey("annotatedKey");
     assertThat(graphVisualizer.shortName(key)).isEqualTo("@Named String");
   }
 
+  @SuppressWarnings("qualifiers")
   @Named("/@<>[]()") String annotatedKeyWithParameters;
   @Test public void testAnnotatedKeyWithParameters() throws Exception {
     String key = fieldKey("annotatedKeyWithParameters");
@@ -62,6 +64,7 @@ public final class GraphVisualizerTest {
         .isEqualTo("Map<java.lang.String, java.util.Set<java.lang.Object>>");
   }
 
+  @SuppressWarnings("qualifiers")
   @Named("/@<>[]()") Map<String, Set<Object>>[] everythingKey;
   @Test public void testEverythingKey() throws Exception {
     String key = fieldKey("everythingKey");


### PR DESCRIPTION
Added the following checks:

<ol>
  <li>Check for <code>@Inject</code> on a <code>final</code> field</li>
  <li> Validate the use of scoping annotations
    <ul>
      <li> error if a scoping annotation is anywhere but a class or method </li>
      <li> error if a scoping annotation is on an abstract class or interface </li>
      <li> error if more than one scoping annotation is on an element where scoping is allowed </li>
      <li> warning if a scoping annotation is on a method that is not a <code>@dagger.Provides</code> method </li>
    </ul> 
  </li>
  <li> Validate the use of qualifier annotations
    <ul> 
      <li> error of more than one qualifier annotation is on an element where qualifiers are allowed (this check was already present; I just moved it.)</li>
      <li> error if a qualifier is anywhere but a field, method, or parameter </li>
      <li> warning if a qualifier is on a non <code>@dagger.Provides</code> method </li>
      <li> warning if a qualifier is on a parameter that is not a <code>@dagger.Provides</code> method parameter or an <code>@Inject</code> constructor parameter </li>
      <li> warning if a qualifier is on a non-injectable field </li>
    </ul> 
  </li>
  <li> Check that <code>@Provides</code> methods are only declared in modules</i>
</ol>


Warnings for misuse of qualifiers can be suppressed with `@SuppressWarnings("qualifiers")`, and warnings for misuse of scoping annotations can be suppressed with `@SuppressWarnings("scoping")`.

Also, take a look at <a href="https://code.google.com/p/error-prone/">error-prone</a>, where I've added lots of general DI checks. The checks in error-prone and here overlap largely, but there are a few that are only in error-prone. For example, I've written error-prone checks to fail if scope and qualifier annotations do not have runtime retention or if a scoping annotation has invalid targeting. (Not all of these checks have been merged into the main error-prone project yet, but if you want to take a look at what's coming, they're all in <a href="https://github.com/sgoldfed/error-prone">my error-prone fork</a>). Also, error-prone has the benefit that it will do the static checks for all DI frameworks.
