### PR TITLE
Moved checkstyle to run before integration tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         </configuration>
         <executions>
           <execution>
-            <phase>verify</phase>
+            <phase>compile</phase>
             <goals>
               <goal>checkstyle</goal>
             </goals>


### PR DESCRIPTION
When developing, on a few occasions I've waited for the integration tests to pass only to then realize that I had a checkstyle error. So, I've been manually running the checkstyle first, but I thought it would be useful to move it to run before the (time consuming) integration tests.
