### PR TITLE
Add gradle section to website

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -408,6 +408,10 @@ public class CoffeeAppModule {
   &lt;optional>true&lt;/optional>
 &lt;/dependency></pre>
 
+            <h4>Gradle</h4>
+            <pre class="prettyprint">compile 'com.squareup.dagger:dagger:<span class="version pln"><em>(insert latest version)</em></span>'
+compile 'com.squareup.dagger:dagger-compiler:<span class="version pln"><em>(insert latest version)</em></span>'</pre>
+
             <h3 id="upgrading">Upgrading from Guice</h3>
 
             <p>Some notable Guice features that Dagger doesn't support:</p>


### PR DESCRIPTION
Would be helpful for newer Gradle users to get started.

I'm not entirely sure if this is the right scoping that should be applied, in which case I'll update the PR. Wanted to have the officially recommended method on the website since I've seen a couple of different solutions on the web.
