### PR TITLE
backfill provides method test for the compiler

### DIFF
--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.google.testing.compile</groupId>
       <artifactId>compile-testing</artifactId>
-      <version>0.3</version>
+      <version>0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/compiler/src/test/java/dagger/tests/integration/codegen/InjectAdapterGenerationTest.java
+++ b/compiler/src/test/java/dagger/tests/integration/codegen/InjectAdapterGenerationTest.java
@@ -76,4 +76,98 @@ public final class InjectAdapterGenerationTest {
         .generatesSources(expectedModuleAdapter, expectedInjectAdapter);
 
   }
+
+  /**
+   * Shows current behavior for a {@link dagger.Provides provides method}
+   * used to supply an injected ctor parameter.
+   *
+   * <ul>
+   *   <li>{@code ProvidesAdapter} invokes the module's provides method on
+   *   {@code get}</li>
+   *   <li>On {@code getBindings}, the above is newed up and linked to its type
+   *   key.
+   *   <li>{@code InjectAdapter} contains a field for the parameter binding,
+   *   referenced in {@code getDependencies} and set on {@code attach}</li>
+   *   <li>On {@code get}, the injected constructor is called with the value of
+   *   {@link dagger.internal.Binding#get}</li>
+   * </ul>
+   */
+  @Test public void providerForCtorInjection() {
+    JavaFileObject sourceFile = JavaFileObjects.forSourceString("Field", Joiner.on("\n").join(
+        "import dagger.Module;",
+        "import dagger.Provides;",
+        "import javax.inject.Inject;",
+        "class Field {",
+        "  static class A { final String name; @Inject A(String name) { this.name = name; }}",
+        "  @Module(injects = A.class)",
+        "  static class AModule { @Provides String name() { return \"foo\"; }}",
+        "}"));
+
+    JavaFileObject expectedModuleAdapter =
+        JavaFileObjects.forSourceString("Field$AModule$$ModuleAdapter", Joiner.on("\n").join(
+        "import dagger.internal.Binding;",
+        "import dagger.internal.ModuleAdapter;",
+        "import java.util.Map;",
+        "import javax.inject.Provider;",
+        "public final class Field$AModule$$ModuleAdapter",
+        "    extends ModuleAdapter<Field.AModule> {",
+        "  private static final String[] INJECTS = {\"members/Field$A\"};",
+        "  private static final Class<?>[] STATIC_INJECTIONS = {};",
+        "  private static final Class<?>[] INCLUDES = {};",
+        "  public Field$AModule$$ModuleAdapter() {",
+        "    super(Field.AModule.class, INJECTS, STATIC_INJECTIONS, false, INCLUDES, true, false);",
+        "  }",
+        "  @Override public Field.AModule newModule() {",
+        "    return new Field.AModule();",
+        "  }",
+        "  @Override public void getBindings(Map<String, Binding<?>> map, Field.AModule module) {",
+        "    map.put(\"java.lang.String\", new NameProvidesAdapter(module));", // eager new!
+        "  }",
+        "  public static final class NameProvidesAdapter", // corresponds to method name
+        "      extends Binding<String> implements Provider<String> {",
+        "    private final Field.AModule module;",
+        "    public NameProvidesAdapter(Field.AModule module) {",
+        "      super(\"java.lang.String\", null, NOT_SINGLETON, \"Field.AModule.name()\");",
+        "      this.module = module;",
+        "      setLibrary(false);",
+        "    }",
+        "    @Override public String get() {",
+        "      return module.name();", // corresponds to @Provides method
+        "    }",
+        "  }",
+        "}"));
+
+    JavaFileObject expectedInjectAdapter =
+        JavaFileObjects.forSourceString("Field$A$$InjectAdapter", Joiner.on("\n").join(
+            "import dagger.internal.Binding;",
+            "import dagger.internal.Linker;",
+            "import java.util.Set;",
+            "import javax.inject.Provider;",
+            "public final class Field$A$$InjectAdapter",
+            "    extends Binding<Field.A> implements Provider<Field.A> {",
+            "  private Binding<String> name;", // for ctor
+            "  public Field$A$$InjectAdapter() {",
+            "    super(\"Field$A\", \"members/Field$A\", NOT_SINGLETON, Field.A.class);",
+            "  }",
+            "  @Override @SuppressWarnings(\"unchecked\")",
+            "  public void attach(Linker linker) {",
+            "    name = (Binding<String>)linker.requestBinding(", // binding key is not a class
+            "      \"java.lang.String\", Field.A.class, getClass().getClassLoader());",
+            "  }",
+            "  @Override public void getDependencies(",
+            "      Set<Binding<?>> getBindings, Set<Binding<?>> injectMembersBindings) {",
+            "    getBindings.add(name);", // name is added to dependencies
+            "  }",
+            "  @Override public Field.A get() {",
+            "    Field.A result = new Field.A(name.get());", // adds ctor param
+            "    return result;",
+            "  }",
+            "}"));
+
+    ASSERT.about(javaSource()).that(sourceFile).processedWith(daggerProcessors())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedModuleAdapter, expectedInjectAdapter);
+
+  }
 }


### PR DESCRIPTION
This backfills a test of how provides methods end up in the current codebase.  Needed before we work on #315

We shouldn't merge this until @cgruber's changes are in (as it will break :) ).
This also needs a release of `compile-testing`.  @gk5885 can you?
