### PR TITLE
Fix interactions between SetBindings and library settings.

### DIFF
--- a/core/src/main/java/dagger/internal/SetBinding.java
+++ b/core/src/main/java/dagger/internal/SetBinding.java
@@ -38,11 +38,14 @@ public final class SetBinding<T> extends Binding<Set<T>> {
     Binding<?> previous = bindings.get(setKey);
     SetBinding<T> setBinding;
     if (previous instanceof SetBinding) {
-      return (SetBinding<T>) previous;
+      setBinding = (SetBinding<T>) previous;
+      setBinding.setLibrary(setBinding.library() && binding.library());
+      return setBinding;
     } else if (previous != null) {
       throw new IllegalArgumentException("Duplicate:\n    " + previous + "\n    " + binding);
     } else {
       setBinding = new SetBinding<T>(setKey, binding.requiredBy);
+      setBinding.setLibrary(binding.library());
       bindings.put(setKey, setBinding);
       return (SetBinding<T>) bindings.get(setKey); // BindingMap.put() copies SetBindings.
     }

--- a/core/src/test/java/dagger/SetBindingTest.java
+++ b/core/src/test/java/dagger/SetBindingTest.java
@@ -38,6 +38,7 @@ import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 @RunWith(JUnit4.class)
 public final class SetBindingTest {
@@ -237,6 +238,55 @@ public final class SetBindingTest {
 
     ObjectGraph graph = ObjectGraph.createWith(new TestingLoader(), new TestModule());
     graph.validate();
+  }
+
+  @Test public void validateLibraryModules() {
+    class TestEntryPoint {}
+
+    @Module(library = true)
+    class SetModule {
+      @Provides(type = SET)
+      public String provideString() {
+        return "";
+      }
+    }
+
+    @Module(injects = TestEntryPoint.class, includes = SetModule.class)
+    class TestModule {}
+
+    ObjectGraph graph = ObjectGraph.createWith(new TestingLoader(),
+        new TestModule(), new SetModule());
+    graph.validate();
+  }
+
+  @Test public void validateLibraryModules_nonLibraryContributors() {
+    class TestEntryPoint {}
+
+    @Module(library = true)
+    class SetModule1 {
+      @Provides(type = SET)
+      public String provideString() {
+        return "a";
+      }
+    }
+
+    @Module
+    class SetModule2 {
+      @Provides(type = SET)
+      public String provideString() {
+        return "b";
+      }
+    }
+
+    @Module(injects = TestEntryPoint.class, includes = { SetModule1.class, SetModule2.class })
+    class TestModule {}
+
+    ObjectGraph graph = ObjectGraph.createWith(new TestingLoader(),
+        new TestModule(), new SetModule1(), new SetModule2());
+    try {
+      graph.validate();
+      fail();
+    } catch (IllegalStateException expected) {}
   }
 
   static class Logger {


### PR DESCRIPTION
SetBindings weren't respecting the library settings of their contributing bindings.  This change fixes SetBindings' copy constructor, and ensures that all of the contributed bindings' library setting is ORed (in effect) so that if all of the bindings came from libraries, then the SetBinding is excluded from orphan analysis - else it is subject to orphan analysis. 
