### PR TITLE
Fix Provides adapter generation when a provides method has a parameter named 'module'

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/ModuleAdapterProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/ModuleAdapterProcessor.java
@@ -485,7 +485,7 @@ public final class ModuleAdapterProcessor extends AbstractProcessor {
       writer.beginMethod("void", "getDependencies", EnumSet.of(PUBLIC), setOfBindings,
           "getBindings", setOfBindings, "injectMembersBindings");
       for (Element parameter : parameters) {
-        writer.emitStatement("getBindings.add(%s)", parameter.getSimpleName().toString());
+        writer.emitStatement("getBindings.add(%s)", parameterName(parameter));
       }
       writer.endMethod();
     }
@@ -499,7 +499,7 @@ public final class ModuleAdapterProcessor extends AbstractProcessor {
     for (Element parameter : parameters) {
       if (!first) args.append(", ");
       else first = false;
-      args.append(String.format("%s.get()", parameter.getSimpleName().toString()));
+      args.append(String.format("%s.get()", parameterName(parameter)));
     }
     writer.emitStatement("return module.%s(%s)", methodName, args.toString());
     writer.endMethod();

--- a/compiler/src/test/java/dagger/tests/integration/codegen/ModuleAdapterGenerationTest.java
+++ b/compiler/src/test/java/dagger/tests/integration/codegen/ModuleAdapterGenerationTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2013 Google Inc.
+ * Copyright (C) 2013 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dagger.tests.integration.codegen;
+
+import com.google.common.base.Joiner;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
+import static dagger.tests.integration.ProcessorTestUtils.daggerProcessors;
+import static java.util.Arrays.asList;
+import static org.truth0.Truth.ASSERT;
+
+@RunWith(JUnit4.class)
+public final class ModuleAdapterGenerationTest {
+
+  @Test public void providesHasParameterNamedModule() {
+    JavaFileObject a = JavaFileObjects.forSourceString("A", Joiner.on("\n").join(
+        "import javax.inject.Inject;",
+        "class A { @Inject A(){ }}"));
+    JavaFileObject b = JavaFileObjects.forSourceString("B", Joiner.on("\n").join(
+        "import javax.inject.Inject;",
+        "class B { @Inject B(){ }}"));
+
+    JavaFileObject module = JavaFileObjects.forSourceString("BModule", Joiner.on("\n").join(
+        "import dagger.Module;",
+        "import dagger.Provides;",
+        "import javax.inject.Inject;",
+        "@Module(injects = B.class)",
+        "class BModule { @Provides B b(A module) { return new B(); }}"));
+
+    ASSERT.about(javaSources()).that(asList(a, b, module)).processedWith(daggerProcessors())
+        .compilesWithoutError();
+  }
+
+}


### PR DESCRIPTION
This was stupid - we had the logic for disambiguation there, used it to generate the field for the parameter binding, and then didn't use it later.  Testing is a healthy software development practice, I feel.  :/

Fixes #350
