### PR TITLE
Avoid duplicate work on .plus() by not re-linking/scanning all the bindings

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/GraphAnalysisProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/GraphAnalysisProcessor.java
@@ -167,7 +167,7 @@ public final class GraphAnalysisProcessor extends AbstractProcessor {
 
     Linker.ErrorHandler errorHandler = ignoreCompletenessErrors ? Linker.ErrorHandler.NULL
         : new GraphAnalysisErrorHandler(processingEnv, rootModule.getQualifiedName().toString());
-    Linker linker = new Linker(new GraphAnalysisLoader(processingEnv), errorHandler);
+    Linker linker = new Linker(null, new GraphAnalysisLoader(processingEnv), errorHandler);
     // Linker requires synchronization for calls to requestBinding and linkAll.
     // We know statically that we're single threaded, but we synchronize anyway
     // to make the linker happy.

--- a/core/src/main/java/dagger/ObjectGraph.java
+++ b/core/src/main/java/dagger/ObjectGraph.java
@@ -201,7 +201,8 @@ public abstract class ObjectGraph {
       }
 
       // Create a linker and install all of the user's bindings
-      Linker linker = new Linker(plugin, new ThrowingErrorHandler());
+      Linker linker =
+          new Linker((base != null) ? base.linker : null, plugin, new ThrowingErrorHandler());
       linker.installBindings(baseBindings);
       linker.installBindings(overrideBindings);
 

--- a/core/src/main/java/dagger/ObjectGraph.java
+++ b/core/src/main/java/dagger/ObjectGraph.java
@@ -160,26 +160,8 @@ public abstract class ObjectGraph {
       Map<String, Class<?>> injectableTypes = new LinkedHashMap<String, Class<?>>();
       Map<Class<?>, StaticInjection> staticInjections
           = new LinkedHashMap<Class<?>, StaticInjection>();
-
-      // Extract bindings in the 'base' and 'overrides' set. Within each set no
-      // duplicates are permitted.
-      UniqueMap<String, Binding<?>> baseBindings = new UniqueMap<String, Binding<?>>() {
-        @Override public Binding<?> put(String key, Binding<?> value) {
-          return super.put(key, (value instanceof SetBinding)
-              ? new SetBinding<Object>((SetBinding<Object>) value) : value);
-        }
-      };
-      if (base != null) {
-        baseBindings.putAll(base.linkEverything()); // Add parent bindings
-      }
-      UniqueMap<String, Binding<?>> overrideBindings = new UniqueMap<String, Binding<?>>() {
-        @Override public Binding<?> put(String key, Binding<?> value) {
-          if (value instanceof SetBinding) {
-            throw new IllegalArgumentException("Module overrides cannot contribute set bindings.");
-          }
-          return super.put(key, value);
-        }
-      };
+      UniqueMap<String, Binding<?>> baseBindings = initBaseBindings(base);
+      UniqueMap<String, Binding<?>> overrideBindings = initOverrideBindings();
 
       Map<ModuleAdapter<?>, Object> loadedModules = Modules.loadModules(plugin, modules);
       for (Entry<ModuleAdapter<?>, Object> loadedModule : loadedModules.entrySet()) {
@@ -207,6 +189,42 @@ public abstract class ObjectGraph {
       linker.installBindings(overrideBindings);
 
       return new DaggerObjectGraph(base, linker, plugin, staticInjections, injectableTypes);
+    }
+
+    /**
+     * Returns an empty {@code UniqueMap} which will throw errors if a SetBinding is added
+     * to it.
+     */
+    private static UniqueMap<String, Binding<?>> initOverrideBindings() {
+      return new UniqueMap<String, Binding<?>>() {
+        @Override public Binding<?> put(String key, Binding<?> value) {
+          if (value instanceof SetBinding) {
+            throw new IllegalArgumentException("Module overrides cannot contribute set bindings.");
+          }
+          return super.put(key, value);
+        }
+      };
+    }
+
+    /**
+     * Extract bindings in the 'base' and 'overrides' set. Within each set no
+     * duplicates are permitted.  Set-bindings are propagated (and cloned) from the parent
+     * to ensure that parent graph participants only see parent bindings, but the child
+     * graph sees parent+child contributions.
+     */
+    private static UniqueMap<String, Binding<?>> initBaseBindings(
+        DaggerObjectGraph base) {
+      UniqueMap<String, Binding<?>> baseBindings = new UniqueMap<String, Binding<?>>();
+      if (base != null) {
+        Map<String, Binding<?>> parentBindings = base.linkEverything();
+        for (Map.Entry<String, Binding<?>> bindingEntry : parentBindings.entrySet()) {
+          if (bindingEntry.getValue() instanceof SetBinding) {
+            baseBindings.put(bindingEntry.getKey(),
+                new SetBinding<Object>((SetBinding<Object>) bindingEntry.getValue()));
+          }
+        }
+      }
+      return baseBindings;
     }
 
     @Override public ObjectGraph plus(Object... modules) {

--- a/core/src/main/java/dagger/ObjectGraph.java
+++ b/core/src/main/java/dagger/ObjectGraph.java
@@ -205,8 +205,7 @@ public abstract class ObjectGraph {
       linker.installBindings(baseBindings);
       linker.installBindings(overrideBindings);
 
-      return new DaggerObjectGraph(base, linker, plugin, staticInjections,
-          injectableTypes);
+      return new DaggerObjectGraph(base, linker, plugin, staticInjections, injectableTypes);
     }
 
     @Override public ObjectGraph plus(Object... modules) {
@@ -240,10 +239,17 @@ public abstract class ObjectGraph {
      * Links all bindings, injectable types and static injections.
      */
     private Map<String, Binding<?>> linkEverything() {
+      Map<String, Binding<?>> bindings = linker.fullyLinkedBindings();
+      if (bindings != null) {
+        return bindings;
+      }
       synchronized (linker) {
+        if ((bindings = linker.fullyLinkedBindings()) != null) {
+          return bindings;
+        }
         linkStaticInjections();
         linkInjectableTypes();
-        return linker.linkAll();
+        return linker.linkAll(); // Linker.linkAll() implicitly does Linker.linkRequested().
       }
     }
 

--- a/core/src/main/java/dagger/internal/Linker.java
+++ b/core/src/main/java/dagger/internal/Linker.java
@@ -15,7 +15,6 @@
  */
 package dagger.internal;
 
-import dagger.ObjectGraph;
 import dagger.internal.Binding.InvalidBindingException;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/core/src/main/java/dagger/internal/Linker.java
+++ b/core/src/main/java/dagger/internal/Linker.java
@@ -31,6 +31,13 @@ import java.util.Set;
 public final class Linker {
   private static final Object UNINITIALIZED = new Object();
 
+  /**
+   * The base {@code Linker} which will be consulted to satisfy bindings not
+   * otherwise satisfiable from this {@code Linker}. The top-most {@code Linker}
+   * in a chain will have a null base linker.
+   */
+  private final Linker base;
+
   /** Bindings requiring a call to attach(). May contain deferred bindings. */
   private final Queue<Binding<?>> toLink = new LinkedList<Binding<?>>();
 
@@ -55,10 +62,11 @@ public final class Linker {
 
   private final ErrorHandler errorHandler;
 
-  public Linker(Loader plugin, ErrorHandler errorHandler) {
+  public Linker(Linker base, Loader plugin, ErrorHandler errorHandler) {
     if (plugin == null) throw new NullPointerException("plugin");
     if (errorHandler == null) throw new NullPointerException("errorHandler");
 
+    this.base = base;
     this.plugin = plugin;
     this.errorHandler = errorHandler;
   }
@@ -261,7 +269,15 @@ public final class Linker {
       boolean mustHaveInjections, boolean library) {
     assertLockHeld();
 
-    Binding<?> binding = bindings.get(key);
+    Binding<?> binding = null;
+    for (Linker linker = this; linker != null; linker = linker.base) {
+      binding = linker.bindings.get(key);
+      if (binding != null) {
+        if (linker != this && !binding.isLinked()) throw new AssertionError();
+        break;
+      }
+    }
+
     if (binding == null) {
       // We can't satisfy this binding. Make sure it'll work next time!
       Binding<?> deferredBinding =


### PR DESCRIPTION
Avoid duplicate work on .plus() by not re-linking all the bindings (or scanning them to determine if they need re-linking, etc.)

This has very bad outcomes in graph configurations with large numbers of bindings in the root graph, and lots of repeated calls to .plus().

This requires a reversion of my prior commit which copies the bindings list into the child graph.  This restores the chained linker structure, because scope/graph depth will not grow anywhere near as much as numbers of bindings will.  This also adapts the prior fix for SetBindings and .plus() to work in this context, by not copying ALL the bindings, but just the SetBindings which need to be cloned into the child graph's bindings to preserve the "union" semantics of child-graph contributions to the set. 

This P/R replaces #349 and in testing inside google massively improves the cost of .plus() when the above mentioned circumstances are in play.  It turns an O(N+M) operation into an (effective) O(M) operation, where N is the number of bindings in the ancestor graph(s), and M is the number of new bindings.  This actually makes Dagger far more viable on a server application, which has a repeated cost of executing .plus() every request - which can be huge numbers of times per second. 

Optimizing one's graph for this would involve moving as many bindings as are semantically correct to move into higher graphs that are initialized fewer times, since .plus() must call linkEverything, but now the cost of linkEverything() is only incurred on the first call to .plus().
