### PR TITLE
A few more changes to eliminate reflection.

### DIFF
--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -41,6 +41,11 @@
       <groupId>com.squareup</groupId>
       <artifactId>javawriter</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>15.0</version>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>
@@ -63,12 +68,6 @@
       <groupId>com.google.testing.compile</groupId>
       <artifactId>compile-testing</artifactId>
       <version>0.4</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>15.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/compiler/src/main/java/dagger/internal/codegen/Util.java
+++ b/compiler/src/main/java/dagger/internal/codegen/Util.java
@@ -16,12 +16,15 @@
  */
 package dagger.internal.codegen;
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
 import dagger.internal.Keys;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import javax.inject.Inject;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.AnnotationValueVisitor;
@@ -31,12 +34,14 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.ErrorType;
 import javax.lang.model.type.PrimitiveType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
+import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.SimpleAnnotationValueVisitor6;
 import javax.lang.model.util.SimpleTypeVisitor6;
 
@@ -236,6 +241,23 @@ final class Util {
     } else {
       return expectedClass == value.getClass();
     }
+  }
+
+  /**
+   * Returns true if the type reflected by this TypeMirror contains @Inject fields.
+   */
+  public static boolean needsMemberInjection(TypeMirror type) {
+    return type.accept(new SimpleTypeVisitor6<Boolean, Void>() {
+      @Override public Boolean visitDeclared(DeclaredType declaredType, Void v) {
+        List<? extends Element> enclosed = declaredType.asElement().getEnclosedElements();
+        return FluentIterable.<VariableElement>from(ElementFilter.fieldsIn(enclosed))
+            .anyMatch(new Predicate<VariableElement>() {
+              @Override public boolean apply(VariableElement e) {
+                return e.getAnnotation(Inject.class) != null;
+              }
+            });
+      }
+    }, null);
   }
 
   // TODO(sgoldfed): better format for other types of elements?

--- a/compiler/src/test/java/dagger/tests/integration/codegen/InjectAdapterGenerationTest.java
+++ b/compiler/src/test/java/dagger/tests/integration/codegen/InjectAdapterGenerationTest.java
@@ -44,7 +44,7 @@ public final class InjectAdapterGenerationTest {
             "import dagger.internal.ModuleAdapter;",
             "public final class Basic$AModule$$ModuleAdapter",
             "    extends ModuleAdapter<Basic.AModule> {",
-            "  private static final String[] INJECTS = {\"members/Basic$A\"};",
+            "  private static final String[] INJECTS = {\"Basic$A\"};",
             "  private static final Class<?>[] STATIC_INJECTIONS = {};",
             "  private static final Class<?>[] INCLUDES = {};",
             "  public Basic$AModule$$ModuleAdapter() {",
@@ -99,7 +99,7 @@ public final class InjectAdapterGenerationTest {
         "import javax.inject.Inject;",
         "class Field {",
         "  static class A { final String name; @Inject A(String name) { this.name = name; }}",
-        "  @Module(injects = A.class)",
+        "  @Module(injects = { A.class, String.class })",
         "  static class AModule { @Provides String name() { return \"foo\"; }}",
         "}"));
 
@@ -111,7 +111,8 @@ public final class InjectAdapterGenerationTest {
         "import javax.inject.Provider;",
         "public final class Field$AModule$$ModuleAdapter",
         "    extends ModuleAdapter<Field.AModule> {",
-        "  private static final String[] INJECTS = {\"members/Field$A\"};",
+        "  private static final String[] INJECTS = ",
+        "      {\"Field$A\", \"java.lang.String\"};",
         "  private static final Class<?>[] STATIC_INJECTIONS = {};",
         "  private static final Class<?>[] INCLUDES = {};",
         "  public Field$AModule$$ModuleAdapter() {",

--- a/compiler/src/test/java/dagger/tests/integration/codegen/ModuleAdapterGenerationTest.java
+++ b/compiler/src/test/java/dagger/tests/integration/codegen/ModuleAdapterGenerationTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
 import static dagger.tests.integration.ProcessorTestUtils.daggerProcessors;
 import static java.util.Arrays.asList;
@@ -30,6 +31,115 @@ import static org.truth0.Truth.ASSERT;
 
 @RunWith(JUnit4.class)
 public final class ModuleAdapterGenerationTest {
+  @Test public void injectsMembersInjectedAndProvidedAndConstructedTypes() {
+    JavaFileObject sourceFile = JavaFileObjects.forSourceString("Field", Joiner.on("\n").join(
+        "import dagger.Module;",
+        "import dagger.Provides;",
+        "import javax.inject.Inject;",
+        "class Field {",
+        "  static class A { final String name; @Inject A(String name) { this.name = name; }}",
+        "  static class B { @Inject String name; }",
+        "  @Module(injects = { A.class, String.class, B.class })",
+        "  static class AModule { @Provides String name() { return \"foo\"; }}",
+        "}"));
+
+    JavaFileObject expectedModuleAdapter =
+        JavaFileObjects.forSourceString("Field$AModule$$ModuleAdapter", Joiner.on("\n").join(
+        "import dagger.internal.Binding;",
+        "import dagger.internal.ModuleAdapter;",
+        "import java.util.Map;",
+        "import javax.inject.Provider;",
+        "public final class Field$AModule$$ModuleAdapter extends ModuleAdapter<Field.AModule> {",
+        "  private static final String[] INJECTS = ",
+        "      {\"Field$A\", \"Field$B\", \"java.lang.String\", \"members/Field$B\"};",
+        "  private static final Class<?>[] STATIC_INJECTIONS = {};",
+        "  private static final Class<?>[] INCLUDES = {};",
+        "  public Field$AModule$$ModuleAdapter() {",
+        "    super(Field.AModule.class, INJECTS, STATIC_INJECTIONS, false, INCLUDES, true, false);",
+        "  }",
+        "  @Override public Field.AModule newModule() {",
+        "    return new Field.AModule();",
+        "  }",
+        "  @Override public void getBindings(Map<String, Binding<?>> map, Field.AModule module) {",
+        "    map.put(\"java.lang.String\", new NameProvidesAdapter(module));", // eager new!
+        "  }",
+        "  public static final class NameProvidesAdapter", // corresponds to method name
+        "      extends Binding<String> implements Provider<String> {",
+        "    private final Field.AModule module;",
+        "    public NameProvidesAdapter(Field.AModule module) {",
+        "      super(\"java.lang.String\", null, NOT_SINGLETON, \"Field.AModule.name()\");",
+        "      this.module = module;",
+        "      setLibrary(false);",
+        "    }",
+        "    @Override public String get() {",
+        "      return module.name();", // corresponds to @Provides method
+        "    }",
+        "  }",
+        "}"));
+
+    JavaFileObject expectedInjectAdapterA =
+        JavaFileObjects.forSourceString("Field$A$$InjectAdapter", Joiner.on("\n").join(
+            "import dagger.internal.Binding;",
+            "import dagger.internal.Linker;",
+            "import java.util.Set;",
+            "import javax.inject.Provider;",
+            "public final class Field$A$$InjectAdapter",
+            "    extends Binding<Field.A> implements Provider<Field.A> {",
+            "  private Binding<String> name;", // For Constructor.
+            "  public Field$A$$InjectAdapter() {",
+            "    super(\"Field$A\", \"members/Field$A\", NOT_SINGLETON, Field.A.class);",
+            "  }",
+            "  @Override @SuppressWarnings(\"unchecked\")",
+            "  public void attach(Linker linker) {",
+            "    name = (Binding<String>)linker.requestBinding(",
+            "      \"java.lang.String\", Field.A.class, getClass().getClassLoader());",
+            "  }",
+            "  @Override public void getDependencies(",
+            "      Set<Binding<?>> getBindings, Set<Binding<?>> injectMembersBindings) {",
+            "    getBindings.add(name);", // Name is added to dependencies.
+            "  }",
+            "  @Override public Field.A get() {",
+            "    Field.A result = new Field.A(name.get());", // Adds constructor parameter.
+            "    return result;",
+            "  }",
+            "}"));
+
+    JavaFileObject expectedInjectAdapterB =
+        JavaFileObjects.forSourceString("Field$B$$InjectAdapter", Joiner.on("\n").join(
+            "import dagger.MembersInjector;",
+            "import dagger.internal.Binding;",
+            "import dagger.internal.Linker;",
+            "import java.util.Set;",
+            "import javax.inject.Provider;",
+            "public final class Field$B$$InjectAdapter",
+            "    extends Binding<Field.B> implements Provider<Field.B>, MembersInjector<Field.B> {",
+            "  private Binding<String> name;", // For field.
+            "  public Field$B$$InjectAdapter() {",
+            "    super(\"Field$B\", \"members/Field$B\", NOT_SINGLETON, Field.B.class);",
+            "  }",
+            "  @Override @SuppressWarnings(\"unchecked\")",
+            "  public void attach(Linker linker) {",
+            "    name = (Binding<String>)linker.requestBinding(",
+            "      \"java.lang.String\", Field.B.class, getClass().getClassLoader());",
+            "  }",
+            "  @Override public void getDependencies(",
+            "      Set<Binding<?>> getBindings, Set<Binding<?>> injectMembersBindings) {",
+            "    injectMembersBindings.add(name);", // Name is added to dependencies.
+            "  }",
+            "  @Override public Field.B get() {",
+            "    Field.B result = new Field.B();",
+            "    injectMembers(result);",
+            "    return result;",
+            "  }",
+            "  @Override public void injectMembers(Field.B object) {",
+            "    object.name = name.get();", // Inject field.
+            "  }",
+            "}"));
+    ASSERT.about(javaSource()).that(sourceFile).processedWith(daggerProcessors())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedModuleAdapter, expectedInjectAdapterA, expectedInjectAdapterB);
+  }
 
   @Test public void providesHasParameterNamedModule() {
     JavaFileObject a = JavaFileObjects.forSourceString("A", Joiner.on("\n").join(
@@ -42,12 +152,10 @@ public final class ModuleAdapterGenerationTest {
     JavaFileObject module = JavaFileObjects.forSourceString("BModule", Joiner.on("\n").join(
         "import dagger.Module;",
         "import dagger.Provides;",
-        "import javax.inject.Inject;",
         "@Module(injects = B.class)",
         "class BModule { @Provides B b(A module) { return new B(); }}"));
 
     ASSERT.about(javaSources()).that(asList(a, b, module)).processedWith(daggerProcessors())
         .compilesWithoutError();
   }
-
 }


### PR DESCRIPTION
Presently ModuleAdapterProcessor generates members/foo.bar.Blah keys for non-interfaces present in the @Module(injects=...) list. This change, instead of simply saying "if class, list a members key", lists the provision key and only generates the members key if the type has injectable fields. It short circuits that logic if the type is provided in an `@Provides` method in the same module, but doesn't short circuit if the type has no `@Inject` constructor, because it may have been provided up-stream by another included module or adds-to referenced module.

In short, if the processor can see the type, and can inspect it, and it has no field injection, no members/foo key will be listed in injects.  But also, if it KNOWS this type will be given through an @Provides method, it will also not list a members key.  This results in a lot less unintentional reflection since dagger will not then attempt to load `InjectAdapter`s for a lot of members keys that are actually already present as provides bindings.

In practice, this was discovered by large graphs with a lot of value types being inserted into the graph and being listed as injectable, forcing a lot of reflective bindings to be created that would never ever be used (since there was no members-injection).
