### PR TITLE
Adding error for fake complete=false module

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/NonCompleteModuleErrorHandler.java
+++ b/compiler/src/main/java/dagger/internal/codegen/NonCompleteModuleErrorHandler.java
@@ -1,0 +1,19 @@
+package dagger.internal.codegen;
+
+import dagger.internal.Linker;
+import java.util.List;
+
+public class NonCompleteModuleErrorHandler implements Linker.ErrorHandler {
+
+  private boolean shouldBeComplete = true;
+
+  @Override public void handleErrors(List<String> errors) {
+    if (errors.size() > 0) {
+      shouldBeComplete = false;
+    }
+  }
+
+  public boolean shouldBeComplete() {
+    return shouldBeComplete;
+  }
+}


### PR DESCRIPTION
It does not make sense to use "complete = false" on a module if there is no missing binding. This can happen after refactorings, or copy pasting. While you can't beat manual review, it also helps to have the compiler let you know that you have it wrong.

I've used this branch to chase our "fake incomplete" modules. Turns out we had more then a few, so I think it might be worth making that a feature.

This commit is not done yet: I can't build, I have mysterious "java.io package not allowed" errors and also apparently I need to upgrade Maven for Android to build. I'll try to fix that done or steal Jake's laptop.

I should also add some tests.

In the meantime, let me know if that sounds like the right way to do it. I wonder if it should live in GraphAnalysisProcessor or not.
