### PR TITLE
Remove Guava from poms

### DIFF
--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -41,10 +41,6 @@
       <groupId>com.squareup</groupId>
       <artifactId>javawriter</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,6 @@
     <java.version>1.6</java.version>
     <javax.inject.version>1</javax.inject.version>
     <javawriter.version>2.3.0</javawriter.version>
-    <guava.version>15.0</guava.version>
 
     <!-- Test Dependencies -->
     <junit.version>4.10</junit.version>
@@ -88,11 +87,6 @@
         <groupId>com.squareup</groupId>
         <artifactId>javawriter</artifactId>
         <version>${javawriter.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${guava.version}</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>


### PR DESCRIPTION
Prevents Guava from leaking into an application using dagger-compiler.

This isn't a normal case of a leaking dependency -- it doesn't make it into final jars because (per the README) dagger-complier is marked provided. However, it makes it into IDEs, of course, and since non-existent annotations are allowed on a class, transitive annotations (such as Guava's @Subscribe) can be a problem.
