### PR TITLE
Do not mask underlying exception message when binding.

### DIFF
--- a/core/src/main/java/dagger/ObjectGraph.java
+++ b/core/src/main/java/dagger/ObjectGraph.java
@@ -184,8 +184,8 @@ public abstract class ObjectGraph {
           BindingsGroup addTo = moduleAdapter.overrides ? overrideBindings : baseBindings;
           moduleAdapter.getBindings(addTo, loadedModule.getValue());
         } catch (IllegalArgumentException e) {
-          throw new IllegalArgumentException(moduleAdapter.moduleClass.getSimpleName()
-              + " is an overriding module and cannot contribute set bindings.");
+          throw new IllegalArgumentException(
+              moduleAdapter.moduleClass.getSimpleName() + ": " + e.getMessage(), e);
         }
       }
 


### PR DESCRIPTION
This change surfaces the exception message from the underlyng cause of a failure to fetch bindings. Prior to this, we assumed that all exceptions were due to overrides being unable to contribute set bindings.

Closes #380.
