### PR TITLE
fixed compile issue: Caused by: java.lang.ClassNotFoundException: com.an...

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -70,7 +70,7 @@
         <plugin>
           <groupId>com.jayway.maven.plugins.android.generation2</groupId>
           <artifactId>android-maven-plugin</artifactId>
-          <version>3.8.0</version>
+          <version>3.8.2</version>
           <configuration>
             <sdk>
               <platform>16</platform>


### PR DESCRIPTION
...droid.sdklib.AndroidVersion$AndroidVersionException

at
org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:130)
... 20 more
Caused by: java.lang.NoClassDefFoundError:
com/android/sdklib/AndroidVersion$AndroidVersionException
at
com.jayway.maven.plugins.android.AbstractAndroidMojo.getAndroidSdk(AbstractAndroidMojo.java:1150)
at
com.jayway.maven.plugins.android.phase01generatesources.GenerateSourcesMojo.generateR(GenerateSourcesMojo.java:547)
at
com.jayway.maven.plugins.android.phase01generatesources.GenerateSourcesMojo.execute(GenerateSourcesMojo.java:211)
at
org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:106)
... 20 more
Caused by: java.lang.ClassNotFoundException:
com.android.sdklib.AndroidVersion$AndroidVersionException
at
org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:50)
at
org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass(ClassRealm.java:259)
at
org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:235)
at
org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:227)
... 24 more
