### PR TITLE
Make the test for dependency cycles less brittle.

### DIFF
--- a/compiler/src/test/java/dagger/tests/integration/validation/CyclicDependencyTest.java
+++ b/compiler/src/test/java/dagger/tests/integration/validation/CyclicDependencyTest.java
@@ -52,9 +52,7 @@ public class CyclicDependencyTest {
         "}"));
 
     ASSERT.about(javaSource()).that(sourceFile).processedWith(daggerProcessors()).failsToCompile()
-        .withErrorContaining("0. CyclicDeps$Foo bound by").in(sourceFile).onLine(17).and()
-        .withErrorContaining("1. CyclicDeps$Bar bound by").in(sourceFile).onLine(17).and()
-        .withErrorContaining("2. CyclicDeps$Blah bound by").in(sourceFile).onLine(17);
+        .withErrorContaining("Dependency cycle:").in(sourceFile).onLine(17);
   }
 
   @Test public void cyclicDepsWithProvidesMethods() {
@@ -76,10 +74,7 @@ public class CyclicDependencyTest {
         "}"));
 
     ASSERT.about(javaSource()).that(sourceFile).processedWith(daggerProcessors()).failsToCompile()
-        .withErrorContaining("0. CyclicDeps$A bound by Provides").in(sourceFile).onLine(9).and()
-        .withErrorContaining("1. CyclicDeps$D bound by Provides").in(sourceFile).onLine(9).and()
-        .withErrorContaining("2. CyclicDeps$C bound by Provides").in(sourceFile).onLine(9).and()
-        .withErrorContaining("3. CyclicDeps$B bound by Provides").in(sourceFile).onLine(9);
+        .withErrorContaining("Dependency cycle:").in(sourceFile).onLine(9);
   }
 
 }


### PR DESCRIPTION
Loosens the brittle assumptions of the cycle detection test which implicitly relies on method processing order.  We don't actually care that A or C is found first - they're a cycle - any node will do.  We just care about the correct error being thrown.  Method processing order is simply undefined but happens to be deterministic within a JVM release, and happened to change in Java8. 
