### PR TITLE
Update JavaWriter to the latest.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <!-- Compilation -->
     <java.version>1.6</java.version>
     <javax.inject.version>1</javax.inject.version>
-    <javawriter.version>2.3.0</javawriter.version>
+    <javawriter.version>2.5.0</javawriter.version>
     <guava.version>15.0</guava.version>
 
     <!-- Test Dependencies -->


### PR DESCRIPTION
Specifically this fixes a problem with handling fully-qualified class names which are nested under 'java.lang' but not directly in the 'java.lang' package (e.g., 'java.lang.ref.WeakReference').

JavaWriter already has tests for this: https://github.com/square/javawriter/blob/master/src/test/java/com/squareup/javawriter/JavaWriterTest.java#L854-L864

Closes #420.
