### PR TITLE
Use Types.isSameType for comparing TypeMirrors.

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/ModuleAdapterProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/ModuleAdapterProcessor.java
@@ -213,7 +213,7 @@ public final class ModuleAdapterProcessor extends AbstractProcessor {
       TypeElement moduleType = (TypeElement) module;
 
       // Verify that all modules do not extend from non-Object types.
-      if (!moduleType.getSuperclass().equals(objectType)) {
+      if (!types.isSameType(moduleType.getSuperclass(), objectType)) {
         error("Modules must not extend from other classes: " + elementToString(module), module);
       }
 


### PR DESCRIPTION
The documentation on TypeMirror.equals states "Semantic comparisons of type equality should instead use Types.isSameType(TypeMirror, TypeMirror). The results of t1.equals(t2) and Types.isSameType(t1, t2) may differ.".

Closes #316.
