### PR TITLE
"apt-get update" before "install" in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ jdk:
   - openjdk7
 
 before_install:
+  - sudo apt-get update -qq
   - sudo apt-get install -qq libstdc++6:i386 lib32z1
   - export COMPONENTS=build-tools-19.0.1,android-16
   - curl -L https://raw.github.com/embarkmobile/android-sdk-installer/version-1/android-sdk-installer | bash /dev/stdin --install=$COMPONENTS


### PR DESCRIPTION
should fix travis build errors like

```
Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/e/eglibc/libc6-dev_2.15-0ubuntu10.5_amd64.deb  404  Not Found [IP: 2001:67c:1360:8c01::19 80]
```
