### PR TITLE
Remove synthetic accessor method generation by increasing visibility.

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/Util.java
+++ b/compiler/src/main/java/dagger/internal/codegen/Util.java
@@ -314,7 +314,7 @@ final class Util {
     }
   }
 
-  private static TypeName box(PrimitiveType primitiveType) {
+  static TypeName box(PrimitiveType primitiveType) {
     switch (primitiveType.getKind()) {
       case BYTE:
         return ClassName.get(Byte.class);

--- a/core/src/main/java/dagger/ObjectGraph.java
+++ b/core/src/main/java/dagger/ObjectGraph.java
@@ -163,7 +163,7 @@ public abstract class ObjectGraph {
       return object;
     }
 
-    private static ObjectGraph makeGraph(DaggerObjectGraph base, Loader plugin, Object... modules) {
+    static ObjectGraph makeGraph(DaggerObjectGraph base, Loader plugin, Object... modules) {
       Map<String, Class<?>> injectableTypes = new LinkedHashMap<String, Class<?>>();
       Map<Class<?>, StaticInjection> staticInjections
           = new LinkedHashMap<Class<?>, StaticInjection>();

--- a/core/src/main/java/dagger/internal/LazyBinding.java
+++ b/core/src/main/java/dagger/internal/LazyBinding.java
@@ -23,13 +23,13 @@ import dagger.Lazy;
  */
 final class LazyBinding<T> extends Binding<Lazy<T>> {
 
-  private final static Object NOT_PRESENT = new Object();
+  final static Object NOT_PRESENT = new Object();
 
   private final String lazyKey;
   private final ClassLoader loader;
-  private Binding<T> delegate;
+  Binding<T> delegate;
 
-  public LazyBinding(String key, Object requiredBy, ClassLoader loader, String lazyKey) {
+  LazyBinding(String key, Object requiredBy, ClassLoader loader, String lazyKey) {
     super(key, null, false, requiredBy);
     this.loader = loader;
     this.lazyKey = lazyKey;

--- a/core/src/main/java/dagger/internal/Linker.java
+++ b/core/src/main/java/dagger/internal/Linker.java
@@ -28,7 +28,7 @@ import java.util.Set;
  * Links bindings to their dependencies.
  */
 public final class Linker {
-  private static final Object UNINITIALIZED = new Object();
+  static final Object UNINITIALIZED = new Object();
 
   /**
    * The base {@code Linker} which will be consulted to satisfy bindings not
@@ -348,7 +348,7 @@ public final class Linker {
     private final Binding<T> binding;
     private volatile Object onlyInstance = UNINITIALIZED;
 
-    private SingletonBinding(Binding<T> binding) {
+    SingletonBinding(Binding<T> binding) {
       super(binding.provideKey, binding.membersKey, true, binding.requiredBy);
       this.binding = binding;
     }
@@ -449,7 +449,7 @@ public final class Linker {
     final String deferredKey;
     final boolean mustHaveInjections;
 
-    private DeferredBinding(String deferredKey, ClassLoader classLoader, Object requiredBy,
+    DeferredBinding(String deferredKey, ClassLoader classLoader, Object requiredBy,
         boolean mustHaveInjections) {
       super(null, null, false, requiredBy);
       this.deferredKey = deferredKey;


### PR DESCRIPTION
This is just the runtime. Going to inspect the generated code next.