### PR TITLE
Remove redundant interface declarations.

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/InjectAdapterProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/InjectAdapterProcessor.java
@@ -22,7 +22,6 @@ import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
-import dagger.MembersInjector;
 import dagger.ObjectGraph;
 import dagger.internal.Binding;
 import dagger.internal.Linker;
@@ -38,7 +37,6 @@ import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.inject.Inject;
-import javax.inject.Provider;
 import javax.inject.Singleton;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
@@ -262,15 +260,6 @@ public final class InjectAdapterProcessor extends AbstractProcessor {
         .superclass(ParameterizedTypeName.get(ClassName.get(Binding.class), injectedClassName))
         .addJavadoc("$L", bindingTypeDocs(injectableType(type.asType()), isAbstract,
             injectMembers, dependent).toString());
-
-    if (constructor != null) {
-      result.addSuperinterface(ParameterizedTypeName.get(
-          ClassName.get(Provider.class), injectedClassName));
-    }
-    if (injectMembers) {
-      result.addSuperinterface(ParameterizedTypeName.get(
-          ClassName.get(MembersInjector.class), injectedClassName));
-    }
 
     for (Element field : fields) {
       result.addField(memberBindingField(disambiguateFields, field));

--- a/compiler/src/main/java/dagger/internal/codegen/ModuleAdapterProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/ModuleAdapterProcessor.java
@@ -410,8 +410,7 @@ public final class ModuleAdapterProcessor extends AbstractProcessor {
     TypeSpec.Builder result = TypeSpec.classBuilder(className.simpleName())
         .addJavadoc("$L", bindingTypeDocs(returnType, false, false, dependent))
         .addModifiers(PUBLIC, STATIC, FINAL)
-        .superclass(ParameterizedTypeName.get(ClassName.get(ProvidesBinding.class), returnType))
-        .addSuperinterface(ParameterizedTypeName.get(ClassName.get(Provider.class), returnType));
+        .superclass(ParameterizedTypeName.get(ClassName.get(ProvidesBinding.class), returnType));
 
     result.addField(moduleClassName, "module", PRIVATE, FINAL);
     for (Element parameter : parameters) {

--- a/compiler/src/test/java/dagger/tests/integration/codegen/InjectAdapterGenerationTest.java
+++ b/compiler/src/test/java/dagger/tests/integration/codegen/InjectAdapterGenerationTest.java
@@ -68,9 +68,8 @@ public final class InjectAdapterGenerationTest {
         JavaFileObjects.forSourceString("Basic$A$$InjectAdapter", Joiner.on("\n").join(
             "import dagger.internal.Binding;",
             "import java.lang.Override;",
-            "import javax.inject.Provider;",
             "public final class Basic$A$$InjectAdapter",
-            "    extends Binding<Basic.A> implements Provider<Basic.A> {",
+            "    extends Binding<Basic.A> {",
             "  public Basic$A$$InjectAdapter() {",
             "    super(\"Basic$A\", \"members/Basic$A\", NOT_SINGLETON, Basic.A.class);",
             "  }",
@@ -84,9 +83,8 @@ public final class InjectAdapterGenerationTest {
         JavaFileObjects.forSourceString("Basic$Foo$Bar$$InjectAdapter", Joiner.on("\n").join(
             "import dagger.internal.Binding;",
             "import java.lang.Override;",
-            "import javax.inject.Provider;",
             "public final class Basic$Foo$Bar$$InjectAdapter",
-            "    extends Binding<Basic.Foo$Bar> implements Provider<Basic.Foo$Bar> {",
+            "    extends Binding<Basic.Foo$Bar> {",
             "  public Basic$Foo$Bar$$InjectAdapter() {",
             "    super(\"Basic$Foo$Bar\", \"members/Basic$Foo$Bar\",",
             "        NOT_SINGLETON, Basic.Foo$Bar.class);",
@@ -101,9 +99,8 @@ public final class InjectAdapterGenerationTest {
         JavaFileObjects.forSourceString("Basic$Foo$Bar$Baz$$InjectAdapter", Joiner.on("\n").join(
             "import dagger.internal.Binding;",
             "import java.lang.Override;",
-            "import javax.inject.Provider;",
             "public final class Basic$Foo$Bar$Baz$$InjectAdapter",
-            "    extends Binding<Basic.Foo$Bar.Baz> implements Provider<Basic.Foo$Bar.Baz> {",
+            "    extends Binding<Basic.Foo$Bar.Baz> {",
             "  public Basic$Foo$Bar$Baz$$InjectAdapter() {",
             "    super(\"Basic$Foo$Bar$Baz\", \"members/Basic$Foo$Bar$Baz\",",
             "        NOT_SINGLETON, Basic.Foo$Bar.Baz.class);",

--- a/compiler/src/test/java/dagger/tests/integration/codegen/ModuleAdapterGenerationTest.java
+++ b/compiler/src/test/java/dagger/tests/integration/codegen/ModuleAdapterGenerationTest.java
@@ -65,7 +65,6 @@ public final class ModuleAdapterGenerationTest {
         "import java.lang.Class;",
         "import java.lang.Override;",
         "import java.lang.String;",
-        "import javax.inject.Provider;",
         "public final class Field$AModule$$ModuleAdapter",
         "    extends ModuleAdapter<Field.AModule> {",
         "  private static final String[] INJECTS = ",
@@ -83,7 +82,7 @@ public final class ModuleAdapterGenerationTest {
         "        new NameProvidesAdapter(module));", // eager new!
         "  }",
         "  public static final class NameProvidesAdapter", // corresponds to method name
-        "      extends ProvidesBinding<String> implements Provider<String> {",
+        "      extends ProvidesBinding<String> {",
         "    private final Field.AModule module;",
         "    public NameProvidesAdapter(Field.AModule module) {",
         "      super(\"java.lang.String\", NOT_SINGLETON, \"Field.AModule\", \"name\");",
@@ -104,9 +103,8 @@ public final class ModuleAdapterGenerationTest {
             "import java.lang.String;",
             "import java.lang.SuppressWarnings;",
             "import java.util.Set;",
-            "import javax.inject.Provider;",
             "public final class Field$A$$InjectAdapter",
-            "    extends Binding<Field.A> implements Provider<Field.A> {",
+            "    extends Binding<Field.A> {",
             "  private Binding<String> name;", // for ctor
             "  public Field$A$$InjectAdapter() {",
             "    super(\"Field$A\", \"members/Field$A\", NOT_SINGLETON, Field.A.class);",
@@ -153,7 +151,6 @@ public final class ModuleAdapterGenerationTest {
         "import java.lang.Class;",
         "import java.lang.Override;",
         "import java.lang.String;",
-        "import javax.inject.Provider;",
         "public final class Field$AModule$$ModuleAdapter extends ModuleAdapter<Field.AModule> {",
         "  private static final String[] INJECTS = ",
         "      {\"members/Field$A\", \"members/java.lang.String\", \"members/Field$B\"};",
@@ -170,7 +167,7 @@ public final class ModuleAdapterGenerationTest {
         "        new NameProvidesAdapter(module));", // eager new!
         "  }",
         "  public static final class NameProvidesAdapter", // corresponds to method name
-        "      extends ProvidesBinding<String> implements Provider<String> {",
+        "      extends ProvidesBinding<String> {",
         "    private final Field.AModule module;",
         "    public NameProvidesAdapter(Field.AModule module) {",
         "      super(\"java.lang.String\", NOT_SINGLETON, \"Field.AModule\", \"name\");",
@@ -191,9 +188,8 @@ public final class ModuleAdapterGenerationTest {
             "import java.lang.String;",
             "import java.lang.SuppressWarnings;",
             "import java.util.Set;",
-            "import javax.inject.Provider;",
             "public final class Field$A$$InjectAdapter",
-            "    extends Binding<Field.A> implements Provider<Field.A> {",
+            "    extends Binding<Field.A> {",
             "  private Binding<String> name;", // For Constructor.
             "  public Field$A$$InjectAdapter() {",
             "    super(\"Field$A\", \"members/Field$A\", NOT_SINGLETON, Field.A.class);",
@@ -215,16 +211,14 @@ public final class ModuleAdapterGenerationTest {
 
     JavaFileObject expectedInjectAdapterB =
         JavaFileObjects.forSourceString("Field$B$$InjectAdapter", Joiner.on("\n").join(
-            "import dagger.MembersInjector;",
             "import dagger.internal.Binding;",
             "import dagger.internal.Linker;",
             "import java.lang.Override;",
             "import java.lang.String;",
             "import java.lang.SuppressWarnings;",
             "import java.util.Set;",
-            "import javax.inject.Provider;",
             "public final class Field$B$$InjectAdapter",
-            "    extends Binding<Field.B> implements Provider<Field.B>, MembersInjector<Field.B> {",
+            "    extends Binding<Field.B> {",
             "  private Binding<String> name;", // For field.
             "  public Field$B$$InjectAdapter() {",
             "    super(\"Field$B\", \"members/Field$B\", NOT_SINGLETON, Field.B.class);",


### PR DESCRIPTION
A Binder of T is a Provider of T and a MembersInjector of T already.