### PR TITLE
Require explicit inject constructor for non-provider instantiation.

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/InjectAdapterProcessor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/InjectAdapterProcessor.java
@@ -52,10 +52,8 @@ import static dagger.internal.codegen.Util.adapterName;
 import static dagger.internal.codegen.Util.bindingOf;
 import static dagger.internal.codegen.Util.elementToString;
 import static dagger.internal.codegen.Util.getApplicationSupertype;
-import static dagger.internal.codegen.Util.getNoArgsConstructor;
 import static dagger.internal.codegen.Util.getPackage;
 import static dagger.internal.codegen.Util.injectableType;
-import static dagger.internal.codegen.Util.isCallableConstructor;
 import static dagger.internal.codegen.Util.rawTypeToString;
 import static dagger.internal.loaders.GeneratedAdapters.INJECT_ADAPTER_SUFFIX;
 import static javax.lang.model.element.Modifier.ABSTRACT;
@@ -212,13 +210,6 @@ public final class InjectAdapterProcessor extends AbstractProcessor {
           // TODO(tbroyer): pass annotation information
           error("Cannot inject " + elementToString(member), member);
           break;
-      }
-    }
-
-    if (constructor == null && !isAbstract) {
-      constructor = getNoArgsConstructor(type);
-      if (constructor != null && !isCallableConstructor(constructor)) {
-        constructor = null;
       }
     }
 

--- a/compiler/src/test/java/dagger/tests/integration/codegen/ModuleAdapterGenerationTest.java
+++ b/compiler/src/test/java/dagger/tests/integration/codegen/ModuleAdapterGenerationTest.java
@@ -219,7 +219,7 @@ public final class ModuleAdapterGenerationTest {
             "    extends Binding<Field.B> {",
             "  private Binding<String> name;", // For field.
             "  public Field$B$$InjectAdapter() {",
-            "    super(\"Field$B\", \"members/Field$B\", NOT_SINGLETON, Field.B.class);",
+            "    super(null, \"members/Field$B\", NOT_SINGLETON, Field.B.class);",
             "  }",
             "  @Override @SuppressWarnings(\"unchecked\")",
             "  public void attach(Linker linker) {",
@@ -229,11 +229,6 @@ public final class ModuleAdapterGenerationTest {
             "  @Override public void getDependencies(",
             "      Set<Binding<?>> getBindings, Set<Binding<?>> injectMembersBindings) {",
             "    injectMembersBindings.add(name);", // Name is added to dependencies.
-            "  }",
-            "  @Override public Field.B get() {",
-            "    Field.B result = new Field.B();",
-            "    injectMembers(result);",
-            "    return result;",
             "  }",
             "  @Override public void injectMembers(Field.B object) {",
             "    object.name = name.get();", // Inject field.

--- a/compiler/src/test/java/dagger/tests/integration/operation/PrimitiveInjectionTest.java
+++ b/compiler/src/test/java/dagger/tests/integration/operation/PrimitiveInjectionTest.java
@@ -36,6 +36,8 @@ public final class PrimitiveInjectionTest {
     @Inject long[] longArray;
     @Inject float[] floatArray;
     @Inject double[] doubleArray;
+
+    @Inject ArrayInjectable() {}
   }
 
   @Module(injects = ArrayInjectable.class)

--- a/core/src/main/java/dagger/internal/FailoverLoader.java
+++ b/core/src/main/java/dagger/internal/FailoverLoader.java
@@ -71,7 +71,7 @@ public final class FailoverLoader extends Loader {
     if (type.isInterface()) {
       return null; // Short-circuit since we can't build reflective bindings for interfaces.
     }
-    return ReflectiveAtInjectBinding.create(type, mustHaveInjections);
+    return ReflectiveAtInjectBinding.create(type);
   }
 
   @Override public StaticInjection getStaticInjection(Class<?> injectedClass) {

--- a/core/src/main/java/dagger/internal/loaders/ReflectiveAtInjectBinding.java
+++ b/core/src/main/java/dagger/internal/loaders/ReflectiveAtInjectBinding.java
@@ -141,7 +141,7 @@ public final class ReflectiveAtInjectBinding<T> extends Binding<T> {
     return provideKey != null ? provideKey : membersKey;
   }
 
-  public static <T> Binding<T> create(Class<T> type, boolean mustHaveInjections) {
+  public static <T> Binding<T> create(Class<T> type) {
     boolean singleton = type.isAnnotationPresent(Singleton.class);
     List<String> keys = new ArrayList<String>();
 
@@ -161,9 +161,7 @@ public final class ReflectiveAtInjectBinding<T> extends Binding<T> {
       }
     }
 
-    // Look up @Inject-annotated constructors. If there's no @Inject-annotated
-    // constructor, use a default public constructor if the class has other
-    // injections. Otherwise treat the class as non-injectable.
+    // Look up @Inject-annotated constructors. Otherwise treat the class as non-injectable.
     Constructor<T> injectedConstructor = null;
     for (Constructor<T> constructor : getConstructorsForType(type)) {
       if (!constructor.isAnnotationPresent(Inject.class)) {
@@ -173,17 +171,6 @@ public final class ReflectiveAtInjectBinding<T> extends Binding<T> {
         throw new InvalidBindingException(type.getName(), "has too many injectable constructors");
       }
       injectedConstructor = constructor;
-    }
-    if (injectedConstructor == null) {
-      if (!injectedFields.isEmpty()) {
-        try {
-          injectedConstructor = type.getDeclaredConstructor();
-        } catch (NoSuchMethodException ignored) {
-        }
-      } else if (mustHaveInjections) {
-        throw new InvalidBindingException(type.getName(),
-            "has no injectable members. Do you want to add an injectable constructor?");
-      }
     }
 
     int parameterCount;

--- a/core/src/test/java/dagger/ExtensionTest.java
+++ b/core/src/test/java/dagger/ExtensionTest.java
@@ -36,18 +36,24 @@ public final class ExtensionTest {
 
   static class B {
     @Inject A a;
+
+    @Inject B() {}
   }
 
   @Singleton
   static class C {
     @Inject A a;
     @Inject B b;
+
+    @Inject C() {}
   }
 
   static class D {
     @Inject A a;
     @Inject B b;
     @Inject C c;
+
+    @Inject D() {}
   }
 
   @Module(injects = { A.class, B.class }) static class RootModule { }

--- a/core/src/test/java/dagger/ExtensionWithSetBindingsTest.java
+++ b/core/src/test/java/dagger/ExtensionWithSetBindingsTest.java
@@ -38,11 +38,15 @@ public final class ExtensionWithSetBindingsTest {
   @Singleton
   static class RealSingleton {
     @Inject Set<Integer> ints;
+
+    @Inject RealSingleton() {}
   }
 
   @Singleton
   static class Main {
     @Inject Set<Integer> ints;
+
+    @Inject Main() {}
   }
 
   @Module(injects = RealSingleton.class)

--- a/core/src/test/java/dagger/ExtensionWithStateTest.java
+++ b/core/src/test/java/dagger/ExtensionWithStateTest.java
@@ -30,6 +30,8 @@ public final class ExtensionWithStateTest {
 
   static class B {
     @Inject A a;
+
+    @Inject B() {}
   }
 
   @Module(

--- a/core/src/test/java/dagger/InjectionTest.java
+++ b/core/src/test/java/dagger/InjectionTest.java
@@ -205,6 +205,8 @@ public final class InjectionTest {
   public static class L {
     @Inject @Named("one") F f;
     @Inject Provider<L> lProvider;
+
+    @Inject L() {}
   }
 
   @Test public void singletonInGraph() {
@@ -238,6 +240,8 @@ public final class InjectionTest {
     @Inject F f1;
     @Inject F f2;
     @Inject Provider<F> fProvider;
+
+    @Inject N() {}
   }
 
   @Test public void noJitBindingsForAnnotations() {
@@ -566,6 +570,9 @@ public final class InjectionTest {
 
   static class ExtendsParameterizedType extends AbstractList<Integer> {
     @Inject String string;
+
+    @Inject ExtendsParameterizedType() {}
+
     @Override public Integer get(int i) {
       throw new AssertionError();
     }
@@ -866,6 +873,8 @@ public final class InjectionTest {
 
   static class SingletonLinkedFromExtension {
     @Inject C c; // Singleton.
+
+    @Inject SingletonLinkedFromExtension() {}
   }
 
   @Module(complete = false, injects = C.class)

--- a/core/src/test/java/dagger/ModuleTest.java
+++ b/core/src/test/java/dagger/ModuleTest.java
@@ -31,6 +31,8 @@ import static org.junit.Assert.fail;
 public final class ModuleTest {
   static class TestEntryPoint {
     @Inject String s;
+
+    @Inject TestEntryPoint() {}
   }
 
   @Module(injects = TestEntryPoint.class)
@@ -137,7 +139,11 @@ public final class ModuleTest {
 
   static class A {}
 
-  static class B { @Inject A a; }
+  static class B {
+    @Inject A a;
+
+    @Inject B() {}
+  }
 
   @Module(injects = A.class) public static class TestModuleA {
     @Provides A a() { return new A(); }

--- a/core/src/test/java/dagger/SetBindingTest.java
+++ b/core/src/test/java/dagger/SetBindingTest.java
@@ -307,6 +307,9 @@ public final class SetBindingTest {
 
   static class Logger {
     @Inject Set<LogSink> loggers;
+
+    @Inject Logger() {}
+
     public void log(String text, Throwable error) {
       LogMessage m = new LogMessage(text, error);
       for (LogSink sink : loggers) {

--- a/core/src/test/java/dagger/ThreadSafetyTest.java
+++ b/core/src/test/java/dagger/ThreadSafetyTest.java
@@ -48,6 +48,8 @@ public final class ThreadSafetyTest {
 
   static class LazyEntryPoint {
     @Inject Lazy<Integer> lazy;
+
+    @Inject LazyEntryPoint() {}
   }
 
   @Module(injects = { Long.class, LazyEntryPoint.class })

--- a/core/src/test/java/dagger/internal/FailoverLoaderTest.java
+++ b/core/src/test/java/dagger/internal/FailoverLoaderTest.java
@@ -25,6 +25,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * A test case to deal with fall-back to reflection where the concrete type has been generated
@@ -53,5 +54,16 @@ public final class FailoverLoaderTest {
     Entry$Point entryPoint = new Entry$Point();
     ObjectGraph.create(new TestModule()).inject(entryPoint);
     assertThat(entryPoint.a).isEqualTo("a");
+  }
+
+  @Test public void noInstantiationWithoutInjectConstructorWithUnGeneratedCode() {
+    ObjectGraph og = ObjectGraph.create(new TestModule());
+    try {
+      og.get(Entry$Point.class);
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage(
+          "Unable to create binding for dagger.internal.FailoverLoaderTest$Entry$Point");
+    }
   }
 }

--- a/core/src/test/java/dagger/internal/TestingLoader.java
+++ b/core/src/test/java/dagger/internal/TestingLoader.java
@@ -37,7 +37,7 @@ public final class TestingLoader extends Loader {
       if (type.isInterface()) {
         return null; // Short-circuit since we can't build reflective bindings for interfaces.
       }
-      return ReflectiveAtInjectBinding.create(type, mustHaveInjections);
+      return ReflectiveAtInjectBinding.create(type);
     } catch (ClassNotFoundException e) {
       throw new TypeNotPresentException(
           String.format("Could not find %s needed for binding %s", className, key), e);

--- a/examples/simple/src/main/java/coffee/CoffeeMaker.java
+++ b/examples/simple/src/main/java/coffee/CoffeeMaker.java
@@ -7,6 +7,10 @@ class CoffeeMaker {
   @Inject Lazy<Heater> heater; // Don't want to create a possibly costly heater until we need it.
   @Inject Pump pump;
 
+  @Inject CoffeeMaker() {
+    // @Inject-annotated constructor required for Dagger to create this type.
+  }
+
   public void brew() {
     heater.get().on();
     pump.pump();


### PR DESCRIPTION
Implement #412 for Dagger 1. Closes #286. Partial solution for #266 when the constructor reference in the inject adapter was an unintentional side-effect.