### PR TITLE
sorting fields for deterministic order

### DIFF
--- a/core/src/main/java/dagger/internal/loaders/ReflectiveAtInjectBinding.java
+++ b/core/src/main/java/dagger/internal/loaders/ReflectiveAtInjectBinding.java
@@ -25,7 +25,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import javax.inject.Inject;
@@ -148,7 +150,14 @@ public final class ReflectiveAtInjectBinding<T> extends Binding<T> {
     // Lookup the injectable fields and their corresponding keys.
     List<Field> injectedFields = new ArrayList<Field>();
     for (Class<?> c = type; c != Object.class; c = c.getSuperclass()) {
-      for (Field field : c.getDeclaredFields()) {
+      Field[] fields = c.getDeclaredFields();
+      Arrays.sort(fields, new Comparator<Object>() {
+        @Override
+        public int compare(Object a, Object b) {
+          return a.toString().compareTo(b.toString());
+        }
+      });
+      for (Field field : fields) {
         if (!field.isAnnotationPresent(Inject.class) || Modifier.isStatic(field.getModifiers())) {
           continue;
         }


### PR DESCRIPTION
When using reflection to get the fields from a class, the order of the fields is not guaranteed to be in any specific order. Some tests, like `multiValueBindings_WithSingletonsAcrossMultipleInjectableTypes`, may fail due to a different ordering returned by `getDeclaredFields`. This PR sorts the field array returned by `getDeclaredFields` to guarantee a deterministic order (in this PR, alphabetical order).

Please let me know if you want to discuss the changes more.